### PR TITLE
fix(db): use families.head_document in fn_reports_unattended_families

### DIFF
--- a/server/db/procedures/reports/fn_reports_unattended_families.sql
+++ b/server/db/procedures/reports/fn_reports_unattended_families.sql
@@ -38,7 +38,7 @@ LANGUAGE sql STABLE AS $$
         SELECT
             f.id                                AS family_id,
             f.family_code                       AS family_code,
-            f.head_of_family_name               AS family_name,
+            f.head_document                     AS family_name,
             f.zone_id,
             z.name                              AS zone_name,
             f.priority_score,


### PR DESCRIPTION
Why: families table exposes head_document (TEXT), not head_of_family_name — migrate step failed with "column f.head_of_family_name does not exist". Aligned with the rest of the codebase (fn_prioritization_*, fn_relocations_*, etc.) which already reads head_document. The JSON field stays named family_name to preserve the API contract.