### PR TITLE
feat(client): Familias y Personas — censo, detalle con puntaje y búsqueda (HU-04/05/06/07/08)

### DIFF
--- a/client/src/api/families.api.ts
+++ b/client/src/api/families.api.ts
@@ -1,6 +1,14 @@
-import { api } from './axios'
+import { api, idempotent } from './axios'
 import type { ApiItem, ApiList } from '@/types/api.types'
-import type { Family, FamilyListParams } from '@/types/family.types'
+import type {
+  Family,
+  FamilyCreatePayload,
+  FamilyEligibility,
+  FamilyListParams,
+  FamilyUpdatePayload,
+} from '@/types/family.types'
+import type { Person } from '@/types/person.types'
+import type { Delivery } from '@/types/delivery.types'
 
 export const familiesApi = {
   // GET /families con filtros (zona, refugio, estado, orden). Ignora `q`:
@@ -25,5 +33,34 @@ export const familiesApi = {
 
   getById(id: number) {
     return api.get<ApiItem<Family>>(`/families/${id}`).then((r) => r.data.data)
+  },
+
+  // POST /families. `clientOpId` (uuid) habilita la idempotencia del backend
+  // para reintentos en redes inestables / sincronización offline (HU-04 CA5).
+  create(payload: FamilyCreatePayload, clientOpId?: string) {
+    return api
+      .post<ApiItem<Family>>('/families', payload, clientOpId ? idempotent(clientOpId) : undefined)
+      .then((r) => r.data.data)
+  },
+
+  update(id: number, payload: FamilyUpdatePayload) {
+    return api.put<ApiItem<Family>>(`/families/${id}`, payload).then((r) => r.data.data)
+  },
+
+  remove(id: number) {
+    return api.delete(`/families/${id}`).then(() => undefined)
+  },
+
+  // Sub-recursos del detalle de familia.
+  listPersons(id: number) {
+    return api.get<ApiItem<Person[]>>(`/families/${id}/persons`).then((r) => r.data.data)
+  },
+
+  listDeliveries(id: number) {
+    return api.get<ApiItem<Delivery[]>>(`/families/${id}/deliveries`).then((r) => r.data.data)
+  },
+
+  getEligibility(id: number) {
+    return api.get<ApiItem<FamilyEligibility>>(`/families/${id}/eligibility`).then((r) => r.data.data)
   },
 }

--- a/client/src/api/persons.api.ts
+++ b/client/src/api/persons.api.ts
@@ -1,0 +1,26 @@
+import { api } from './axios'
+import type { ApiItem } from '@/types/api.types'
+import type { Person, PersonPayload, PersonWithFamily } from '@/types/person.types'
+
+export const personsApi = {
+  // GET /persons/search?document= — búsqueda exacta por documento (HU-06).
+  // Devuelve la persona junto a su familia. Lanza 404 si no existe.
+  findByDocument(document: string) {
+    return api
+      .get<ApiItem<PersonWithFamily>>('/persons/search', { params: { document } })
+      .then((r) => r.data.data)
+  },
+
+  create(payload: PersonPayload) {
+    return api.post<ApiItem<Person>>('/persons', payload).then((r) => r.data.data)
+  },
+
+  // En PUT no se reasigna family_id; se omite del cuerpo.
+  update(id: number, payload: Omit<PersonPayload, 'family_id'>) {
+    return api.put<ApiItem<Person>>(`/persons/${id}`, payload).then((r) => r.data.data)
+  },
+
+  remove(id: number) {
+    return api.delete(`/persons/${id}`).then(() => undefined)
+  },
+}

--- a/client/src/components/layout/AppSidebar.vue
+++ b/client/src/components/layout/AppSidebar.vue
@@ -8,6 +8,7 @@ import {
   LayoutDashboard,
   Map,
   Users,
+  UserSearch,
   Home,
   Warehouse,
   Package,
@@ -48,6 +49,7 @@ const groups: NavGroup[] = [
     title: 'Censo',
     items: [
       { label: 'Familias', to: '/families', icon: Users },
+      { label: 'Buscar Personas', to: '/persons/search', icon: UserSearch },
       { label: 'Zonas', to: '/zones', icon: Home, roles: ['ADMIN', 'COORDINADOR_LOGISTICA'] },
       { label: 'Refugios', to: '/shelters', icon: Home, roles: ['ADMIN', 'COORDINADOR_LOGISTICA'] },
     ],

--- a/client/src/composables/useFamilies.ts
+++ b/client/src/composables/useFamilies.ts
@@ -1,7 +1,7 @@
-import { useQuery, keepPreviousData } from '@tanstack/vue-query'
-import type { Ref } from 'vue'
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/vue-query'
+import { computed, type Ref } from 'vue'
 import { familiesApi } from '@/api/families.api'
-import type { FamilyListParams } from '@/types/family.types'
+import type { FamilyCreatePayload, FamilyListParams, FamilyUpdatePayload } from '@/types/family.types'
 
 // Listado de familias. La key incluye los params reactivos: al cambiar filtros
 // o página, vue-query refetch-ea. placeholderData mantiene la página previa
@@ -12,4 +12,61 @@ export function useFamiliesList(params: Ref<FamilyListParams>) {
     queryFn: () => (params.value.q ? familiesApi.search(params.value) : familiesApi.list(params.value)),
     placeholderData: keepPreviousData,
   })
+}
+
+// Detalle de una familia (HU-08). Incluye priority_score vivo + desglose.
+export function useFamily(id: Ref<number>) {
+  return useQuery({
+    queryKey: ['families', 'detail', id],
+    queryFn: () => familiesApi.getById(id.value),
+    enabled: computed(() => id.value > 0),
+  })
+}
+
+export function useFamilyPersons(id: Ref<number>) {
+  return useQuery({
+    queryKey: ['families', 'persons', id],
+    queryFn: () => familiesApi.listPersons(id.value),
+    enabled: computed(() => id.value > 0),
+  })
+}
+
+export function useFamilyDeliveries(id: Ref<number>) {
+  return useQuery({
+    queryKey: ['families', 'deliveries', id],
+    queryFn: () => familiesApi.listDeliveries(id.value),
+    enabled: computed(() => id.value > 0),
+  })
+}
+
+export function useFamilyEligibility(id: Ref<number>) {
+  return useQuery({
+    queryKey: ['families', 'eligibility', id],
+    queryFn: () => familiesApi.getEligibility(id.value),
+    enabled: computed(() => id.value > 0),
+  })
+}
+
+// Mutaciones de familia. Invalida familias (lista + detalle + sub-recursos) y la
+// priorización (el ranking depende del puntaje).
+export function useFamilyMutations() {
+  const qc = useQueryClient()
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: ['families'] })
+    qc.invalidateQueries({ queryKey: ['prioritization'] })
+  }
+
+  const create = useMutation({
+    mutationFn: ({ payload, clientOpId }: { payload: FamilyCreatePayload; clientOpId?: string }) =>
+      familiesApi.create(payload, clientOpId),
+    onSuccess: invalidate,
+  })
+  const update = useMutation({
+    mutationFn: ({ id, payload }: { id: number; payload: FamilyUpdatePayload }) =>
+      familiesApi.update(id, payload),
+    onSuccess: invalidate,
+  })
+  const remove = useMutation({ mutationFn: familiesApi.remove, onSuccess: invalidate })
+
+  return { create, update, remove }
 }

--- a/client/src/composables/usePersons.ts
+++ b/client/src/composables/usePersons.ts
@@ -1,0 +1,37 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query'
+import { computed, type Ref } from 'vue'
+import { personsApi } from '@/api/persons.api'
+import type { PersonPayload } from '@/types/person.types'
+
+// Mutaciones de persona. Cada alta/edición/baja recalcula los conteos y el
+// puntaje de la familia en el backend (#14, RN-08); por eso invalidamos también
+// familias y priorización para que el detalle y el ranking reflejen el cambio.
+export function usePersonMutations() {
+  const qc = useQueryClient()
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: ['families'] })
+    qc.invalidateQueries({ queryKey: ['prioritization'] })
+  }
+
+  const create = useMutation({ mutationFn: personsApi.create, onSuccess: invalidate })
+  const update = useMutation({
+    mutationFn: ({ id, payload }: { id: number; payload: Omit<PersonPayload, 'family_id'> }) =>
+      personsApi.update(id, payload),
+    onSuccess: invalidate,
+  })
+  const remove = useMutation({ mutationFn: personsApi.remove, onSuccess: invalidate })
+
+  return { create, update, remove }
+}
+
+// Búsqueda por documento (HU-06). Reactiva: el page setea `document` al enviar;
+// solo dispara con ≥3 caracteres. retry:false para que un 404 (no encontrado)
+// se refleje de inmediato como isError.
+export function usePersonSearch(document: Ref<string>) {
+  return useQuery({
+    queryKey: ['persons', 'search', document],
+    queryFn: () => personsApi.findByDocument(document.value.trim()),
+    enabled: computed(() => document.value.trim().length >= 3),
+    retry: false,
+  })
+}

--- a/client/src/pages/families/FamilyDetailPage.vue
+++ b/client/src/pages/families/FamilyDetailPage.vue
@@ -1,28 +1,580 @@
 <script setup lang="ts">
+import { computed, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { ArrowLeft } from '@lucide/vue'
-import AppButton from '@/components/ui/AppButton.vue'
+import { toast } from 'vue-sonner'
+import {
+  ArrowLeft, Pencil, Trash2, UserPlus, Users, Truck, ShieldCheck,
+  CheckCircle2, XCircle, RotateCcw, Pill,
+} from '@lucide/vue'
+import {
+  useFamily, useFamilyPersons, useFamilyDeliveries, useFamilyEligibility, useFamilyMutations,
+} from '@/composables/useFamilies'
+import { usePersonMutations } from '@/composables/usePersons'
+import { useZones } from '@/composables/useZones'
+import { useShelters } from '@/composables/useShelters'
+import type { FamilyScoreBreakdown } from '@/types/family.types'
+import {
+  RELATIONSHIP_LABELS, RELATIONSHIP_OPTIONS, GENDER_OPTIONS,
+  SPECIAL_CONDITION_OPTIONS, SPECIAL_CONDITION_LABELS, ageFromBirthDate,
+} from '@/types/person.types'
+import type { Person, PersonPayload, SpecialCondition } from '@/types/person.types'
+import type { Delivery } from '@/types/delivery.types'
+import { personSchema } from '@/schemas/person.schema'
+import { validate } from '@/utils/validation'
+import { apiErrorMessage } from '@/utils/apiError'
 import PageHeader from '@/components/ui/PageHeader.vue'
+import AppButton from '@/components/ui/AppButton.vue'
+import DataTable from '@/components/ui/DataTable.vue'
+import EmptyState from '@/components/ui/EmptyState.vue'
+import SkeletonBlock from '@/components/ui/SkeletonBlock.vue'
+import FamilyStatusBadge from '@/components/ui/FamilyStatusBadge.vue'
+import RiskLevelBadge from '@/components/ui/RiskLevelBadge.vue'
+import StatusBadge from '@/components/ui/StatusBadge.vue'
+import ScoreBreakdown from '@/components/ui/ScoreBreakdown.vue'
+import BaseModal from '@/components/ui/BaseModal.vue'
+import ConfirmDialog from '@/components/ui/ConfirmDialog.vue'
+import FormField from '@/components/form/FormField.vue'
+import SelectField from '@/components/form/SelectField.vue'
+import MapPicker from '@/components/form/MapPicker.vue'
+import RoleGate from '@/components/auth/RoleGate.vue'
 
 const route = useRoute()
 const router = useRouter()
+const familyId = computed(() => Number(route.params.id))
+
+const EDIT_ROLES = ['ADMIN', 'COORDINADOR_LOGISTICA', 'CENSADOR'] as const
+const DELETE_ROLES = ['ADMIN', 'COORDINADOR_LOGISTICA'] as const
+
+const { data: family, isLoading, isError, refetch } = useFamily(familyId)
+const { data: persons, isLoading: loadingPersons } = useFamilyPersons(familyId)
+const { data: deliveries, isLoading: loadingDeliveries } = useFamilyDeliveries(familyId)
+const { data: eligibility, isLoading: loadingEligibility } = useFamilyEligibility(familyId)
+const { data: zones } = useZones()
+const { data: shelters } = useShelters()
+const { remove: removeFamily } = useFamilyMutations()
+const personMut = usePersonMutations()
+
+const zone = computed(() => (zones.value ?? []).find((z) => z.id === family.value?.zone_id))
+const shelter = computed(() =>
+  family.value?.shelter_id ? (shelters.value ?? []).find((s) => s.id === family.value!.shelter_id) : undefined,
+)
+
+const asPerson = (r: unknown) => r as Person
+const asDelivery = (r: unknown) => r as Delivery
+
+// --- Puntaje de prioridad (HU-08 CA2) -----------------------------------------
+const breakdown = computed(() => family.value?.priority_score_breakdown as FamilyScoreBreakdown | undefined)
+const scoreFactors = computed(() => {
+  const b = breakdown.value
+  if (!b || typeof b.members !== 'number') return []
+  const raw = [
+    { name: 'Integrantes', points: b.members },
+    { name: 'Niños < 5', points: b.children_u5 },
+    { name: 'Adultos > 65', points: b.adults_o65 },
+    { name: 'Gestantes', points: b.pregnant },
+    { name: 'Discapacidad', points: b.disabled },
+    { name: 'Riesgo de zona', points: b.zone_risk },
+    { name: 'Días sin ayuda', points: b.days_no_aid },
+  ]
+  const maxPts = Math.max(1, ...raw.map((f) => f.points))
+  return raw.map((f) => ({ name: f.name, points: Math.round(f.points), max: Math.round(maxPts) }))
+})
+const positiveSum = computed(() => scoreFactors.value.reduce((a, f) => a + f.points, 0))
+const deliveriesPenalty = computed(() => Math.round(breakdown.value?.deliveries ?? 0))
+const scoreValue = computed(() => Math.round(family.value?.priority_score ?? 0))
+
+// --- Pestañas -----------------------------------------------------------------
+type Tab = 'members' | 'deliveries' | 'eligibility'
+const tab = ref<Tab>('members')
+const tabs = computed(() => [
+  { key: 'members' as Tab, label: 'Miembros', icon: Users, count: persons.value?.length },
+  { key: 'deliveries' as Tab, label: 'Entregas', icon: Truck, count: deliveries.value?.length },
+  { key: 'eligibility' as Tab, label: 'Elegibilidad', icon: ShieldCheck, count: undefined as number | undefined },
+])
+
+const personColumns = [
+  { key: 'name', label: 'Nombre' },
+  { key: 'document', label: 'Documento', mono: true },
+  { key: 'age', label: 'Edad', align: 'center' as const },
+  { key: 'relationship', label: 'Parentesco' },
+  { key: 'conditions', label: 'Condiciones' },
+  { key: 'actions', label: '', align: 'right' as const },
+]
+const deliveryColumns = [
+  { key: 'delivery_code', label: 'Código', mono: true },
+  { key: 'delivery_date', label: 'Fecha' },
+  { key: 'coverage_days', label: 'Cobertura', align: 'center' as const },
+  { key: 'items', label: 'Ítems', align: 'center' as const },
+  { key: 'status', label: 'Estado' },
+]
+
+function ageLabel(birth: string) {
+  const a = ageFromBirthDate(birth)
+  return a <= 0 ? '< 1 año' : `${a} años`
+}
+function fmtDate(s: string | null) {
+  if (!s) return '—'
+  return new Date(s).toLocaleDateString('es-CO', { day: '2-digit', month: 'short', year: 'numeric' })
+}
+function fmtDateTime(s: string | null) {
+  if (!s) return '—'
+  return new Date(s).toLocaleString('es-CO', { dateStyle: 'medium', timeStyle: 'short' })
+}
+
+// --- Modal de persona ---------------------------------------------------------
+const personModalOpen = ref(false)
+const personEditId = ref<number | null>(null)
+const personErrors = ref<Record<string, string>>({})
+const personSaving = computed(() => personMut.create.isPending.value || personMut.update.isPending.value)
+const todayStr = new Date().toISOString().slice(0, 10)
+
+function blankPerson() {
+  return {
+    name: '',
+    document: '',
+    birth_date: '',
+    gender: '',
+    relationship: '',
+    special_conditions: [] as SpecialCondition[],
+    requires_medication: false,
+  }
+}
+const personForm = ref(blankPerson())
+const genderOptions = [{ value: '', label: 'Selecciona…' }, ...GENDER_OPTIONS]
+const relationshipOptions = [{ value: '', label: 'Selecciona…' }, ...RELATIONSHIP_OPTIONS]
+
+function openCreatePerson() {
+  personEditId.value = null
+  personForm.value = blankPerson()
+  personErrors.value = {}
+  personModalOpen.value = true
+}
+function openEditPerson(p: Person) {
+  personEditId.value = p.id
+  personForm.value = {
+    name: p.name,
+    document: p.document,
+    birth_date: p.birth_date,
+    gender: p.gender,
+    relationship: p.relationship,
+    special_conditions: [...p.special_conditions],
+    requires_medication: p.requires_medication,
+  }
+  personErrors.value = {}
+  personModalOpen.value = true
+}
+function toggleCondition(c: SpecialCondition) {
+  const arr = personForm.value.special_conditions
+  const i = arr.indexOf(c)
+  if (i >= 0) arr.splice(i, 1)
+  else arr.push(c)
+}
+
+async function submitPerson() {
+  const res = validate(personSchema, { ...personForm.value })
+  if (!res.ok) {
+    personErrors.value = res.errors
+    return
+  }
+  personErrors.value = {}
+  try {
+    if (personEditId.value != null) {
+      await personMut.update.mutateAsync({ id: personEditId.value, payload: res.data })
+      toast.success('Integrante actualizado')
+    } else {
+      const payload: PersonPayload = { family_id: familyId.value, ...res.data }
+      await personMut.create.mutateAsync(payload)
+      toast.success('Integrante agregado')
+    }
+    personModalOpen.value = false
+  } catch (e) {
+    toast.error(apiErrorMessage(e, 'No se pudo guardar. ¿El documento ya está registrado?'))
+  }
+}
+
+// --- Eliminar persona ---------------------------------------------------------
+const personConfirmOpen = ref(false)
+const personTarget = ref<Person | null>(null)
+function askDeletePerson(p: Person) {
+  personTarget.value = p
+  personConfirmOpen.value = true
+}
+async function confirmDeletePerson() {
+  if (!personTarget.value) return
+  try {
+    await personMut.remove.mutateAsync(personTarget.value.id)
+    toast.success('Integrante eliminado')
+  } catch (e) {
+    toast.error(apiErrorMessage(e, 'No se puede eliminar al último integrante del núcleo.'))
+  } finally {
+    personConfirmOpen.value = false
+    personTarget.value = null
+  }
+}
+
+// --- Eliminar familia ---------------------------------------------------------
+const familyConfirmOpen = ref(false)
+async function confirmDeleteFamily() {
+  try {
+    await removeFamily.mutateAsync(familyId.value)
+    toast.success('Familia eliminada')
+    router.push('/families')
+  } catch (e) {
+    toast.error(apiErrorMessage(e, 'No se pudo eliminar: la familia tiene integrantes o entregas asociadas.'))
+  } finally {
+    familyConfirmOpen.value = false
+  }
+}
 </script>
 
 <template>
   <section class="space-y-5">
-    <PageHeader
-      title="Detalle de familia"
-      :crumb="`Familias · #${route.params.id}`"
-      subtitle="Pantalla pendiente (HU-08: puntaje con desglose + pestañas)"
+    <!-- Carga / error -->
+    <div v-if="isLoading" class="space-y-4">
+      <SkeletonBlock height="120px" />
+      <SkeletonBlock height="200px" />
+    </div>
+    <div v-else-if="isError || !family" class="rounded-lg border border-danger-br bg-danger-bg p-6 text-center">
+      <p class="text-sm text-danger">No se pudo cargar la familia.</p>
+      <AppButton variant="outline" size="sm" class="mt-3" @click="() => refetch()">
+        <RotateCcw /> Reintentar
+      </AppButton>
+    </div>
+
+    <template v-else>
+      <PageHeader :title="family.family_code" :crumb="`Familias · ${family.head_document}`">
+        <template #actions>
+          <AppButton variant="outline" @click="router.push('/families')"><ArrowLeft /> Volver</AppButton>
+          <RoleGate :roles="[...EDIT_ROLES]">
+            <AppButton variant="outline" @click="router.push(`/families/${familyId}/edit`)">
+              <Pencil /> Editar
+            </AppButton>
+          </RoleGate>
+          <RoleGate :roles="[...DELETE_ROLES]">
+            <AppButton variant="ghost" class="text-danger" @click="familyConfirmOpen = true">
+              <Trash2 /> Eliminar
+            </AppButton>
+          </RoleGate>
+        </template>
+      </PageHeader>
+
+      <!-- Resumen + Puntaje -->
+      <div class="grid grid-cols-1 gap-5 lg:grid-cols-3">
+        <!-- Datos -->
+        <div class="space-y-4 lg:col-span-2">
+          <div class="rounded-lg border border-neutral-200 bg-white p-5">
+            <div class="flex flex-wrap items-center gap-3">
+              <FamilyStatusBadge :status="family.status" />
+              <span v-if="zone" class="flex items-center gap-2 text-sm text-neutral-600">
+                {{ zone.name }} <RiskLevelBadge :level="zone.risk_level" />
+              </span>
+            </div>
+            <dl class="mt-4 grid grid-cols-2 gap-4 text-sm sm:grid-cols-3">
+              <div>
+                <dt class="text-neutral-500">Documento jefe</dt>
+                <dd class="font-mono font-medium text-neutral-900">{{ family.head_document }}</dd>
+              </div>
+              <div>
+                <dt class="text-neutral-500">Refugio</dt>
+                <dd class="font-medium text-neutral-900">{{ shelter?.name ?? 'Sin refugio' }}</dd>
+              </div>
+              <div>
+                <dt class="text-neutral-500">Integrantes</dt>
+                <dd class="font-medium text-neutral-900">{{ family.num_members }}</dd>
+              </div>
+              <div>
+                <dt class="text-neutral-500">Dirección</dt>
+                <dd class="font-medium text-neutral-900">{{ family.reference_address ?? '—' }}</dd>
+              </div>
+              <div>
+                <dt class="text-neutral-500">Registrada</dt>
+                <dd class="font-medium text-neutral-900">{{ fmtDate(family.created_at) }}</dd>
+              </div>
+            </dl>
+
+            <!-- Composición rápida -->
+            <div class="mt-4 flex flex-wrap gap-2">
+              <span v-if="family.num_children_under_5" class="rounded-full bg-neutral-100 px-2.5 py-1 text-xs text-neutral-600">
+                {{ family.num_children_under_5 }} niño(s) &lt; 5
+              </span>
+              <span v-if="family.num_adults_over_65" class="rounded-full bg-neutral-100 px-2.5 py-1 text-xs text-neutral-600">
+                {{ family.num_adults_over_65 }} adulto(s) &gt; 65
+              </span>
+              <span v-if="family.num_pregnant" class="rounded-full bg-neutral-100 px-2.5 py-1 text-xs text-neutral-600">
+                {{ family.num_pregnant }} gestante(s)
+              </span>
+              <span v-if="family.num_disabled" class="rounded-full bg-neutral-100 px-2.5 py-1 text-xs text-neutral-600">
+                {{ family.num_disabled }} con discapacidad
+              </span>
+            </div>
+          </div>
+
+          <!-- Mini-mapa -->
+          <div v-if="family.latitude != null && family.longitude != null" class="rounded-lg border border-neutral-200 bg-white p-2">
+            <MapPicker
+              :latitude="family.latitude"
+              :longitude="family.longitude"
+              readonly
+              height="220px"
+            />
+          </div>
+        </div>
+
+        <!-- Tarjeta de puntaje -->
+        <div class="rounded-lg border border-neutral-200 bg-white p-5">
+          <h2 class="mb-4 text-sm font-semibold text-neutral-700">Puntaje de prioridad</h2>
+          <ScoreBreakdown
+            v-if="scoreFactors.length"
+            :factors="scoreFactors"
+            :total="scoreValue"
+            :out-of="Math.max(positiveSum, scoreValue, 1)"
+          />
+          <div v-else class="text-center">
+            <p class="text-3xl font-bold text-primary-700">{{ scoreValue }}</p>
+            <p class="text-sm text-neutral-500">Puntaje de prioridad</p>
+          </div>
+          <p v-if="deliveriesPenalty < 0" class="mt-3 border-t border-neutral-200 pt-3 text-xs text-neutral-500">
+            Penalización por entregas previas: <strong class="text-neutral-700">{{ deliveriesPenalty }}</strong>
+          </p>
+        </div>
+      </div>
+
+      <!-- Pestañas -->
+      <div>
+        <div class="flex gap-1 border-b border-neutral-200">
+          <button
+            v-for="t in tabs"
+            :key="t.key"
+            :class="[
+              'flex items-center gap-2 border-b-2 px-4 py-2.5 text-sm font-medium transition-colors',
+              tab === t.key
+                ? 'border-primary-600 text-primary-700'
+                : 'border-transparent text-neutral-500 hover:text-neutral-700',
+            ]"
+            @click="tab = t.key"
+          >
+            <component :is="t.icon" class="h-4 w-4" />
+            {{ t.label }}
+            <span v-if="t.count != null" class="rounded-full bg-neutral-100 px-1.5 text-xs text-neutral-600">
+              {{ t.count }}
+            </span>
+          </button>
+        </div>
+
+        <div class="pt-4">
+          <!-- Miembros -->
+          <div v-show="tab === 'members'" class="space-y-4">
+            <div class="flex justify-end">
+              <RoleGate :roles="[...EDIT_ROLES]">
+                <AppButton size="sm" @click="openCreatePerson"><UserPlus /> Agregar miembro</AppButton>
+              </RoleGate>
+            </div>
+            <div v-if="loadingPersons" class="space-y-2 rounded-lg border border-neutral-200 bg-white p-4">
+              <SkeletonBlock v-for="n in 4" :key="n" height="40px" />
+            </div>
+            <DataTable v-else :columns="personColumns" :rows="persons ?? []" row-key="id" min-width="760px">
+              <template #name="{ row }">
+                <span class="font-medium text-neutral-900">{{ asPerson(row).name }}</span>
+                <span v-if="asPerson(row).requires_medication" class="ml-2 inline-flex items-center gap-1 rounded-full bg-warning-bg px-2 py-0.5 text-xs text-warning">
+                  <Pill class="h-3 w-3" /> Medicación
+                </span>
+              </template>
+              <template #age="{ row }">{{ ageLabel(asPerson(row).birth_date) }}</template>
+              <template #relationship="{ row }">{{ RELATIONSHIP_LABELS[asPerson(row).relationship] }}</template>
+              <template #conditions="{ row }">
+                <div class="flex flex-wrap gap-1">
+                  <span
+                    v-for="c in asPerson(row).special_conditions"
+                    :key="c"
+                    class="rounded-full bg-info-bg px-2 py-0.5 text-xs text-primary-700"
+                  >
+                    {{ SPECIAL_CONDITION_LABELS[c] }}
+                  </span>
+                  <span v-if="!asPerson(row).special_conditions.length" class="text-xs text-neutral-400">—</span>
+                </div>
+              </template>
+              <template #actions="{ row }">
+                <div class="flex justify-end gap-1">
+                  <RoleGate :roles="[...EDIT_ROLES]">
+                    <AppButton variant="ghost" size="sm" @click="openEditPerson(asPerson(row))"><Pencil /></AppButton>
+                  </RoleGate>
+                  <RoleGate :roles="[...DELETE_ROLES]">
+                    <AppButton variant="ghost" size="sm" class="text-danger" @click="askDeletePerson(asPerson(row))">
+                      <Trash2 />
+                    </AppButton>
+                  </RoleGate>
+                </div>
+              </template>
+              <template #empty>
+                <EmptyState title="Sin integrantes" message="Agrega los miembros del núcleo familiar para calcular su composición y puntaje.">
+                  <template #icon><Users /></template>
+                  <template #action>
+                    <RoleGate :roles="[...EDIT_ROLES]">
+                      <AppButton size="sm" @click="openCreatePerson"><UserPlus /> Agregar miembro</AppButton>
+                    </RoleGate>
+                  </template>
+                </EmptyState>
+              </template>
+            </DataTable>
+          </div>
+
+          <!-- Entregas -->
+          <div v-show="tab === 'deliveries'">
+            <div v-if="loadingDeliveries" class="space-y-2 rounded-lg border border-neutral-200 bg-white p-4">
+              <SkeletonBlock v-for="n in 3" :key="n" height="40px" />
+            </div>
+            <DataTable v-else :columns="deliveryColumns" :rows="deliveries ?? []" row-key="id" min-width="640px">
+              <template #delivery_date="{ row }">{{ fmtDate(asDelivery(row).delivery_date) }}</template>
+              <template #coverage_days="{ row }">{{ asDelivery(row).coverage_days }} días</template>
+              <template #items="{ row }">{{ asDelivery(row).details?.length ?? '—' }}</template>
+              <template #status="{ row }"><StatusBadge :status="asDelivery(row).status" /></template>
+              <template #empty>
+                <EmptyState title="Sin entregas" message="Esta familia aún no ha recibido entregas de ayuda.">
+                  <template #icon><Truck /></template>
+                </EmptyState>
+              </template>
+            </DataTable>
+          </div>
+
+          <!-- Elegibilidad -->
+          <div v-show="tab === 'eligibility'">
+            <div v-if="loadingEligibility" class="rounded-lg border border-neutral-200 bg-white p-6">
+              <SkeletonBlock height="80px" />
+            </div>
+            <div v-else-if="eligibility" class="rounded-lg border border-neutral-200 bg-white p-6">
+              <div
+                :class="[
+                  'flex items-center gap-3 rounded-md border p-4',
+                  eligibility.is_eligible
+                    ? 'border-success-br bg-success-bg text-success'
+                    : 'border-warning-br bg-warning-bg text-warning',
+                ]"
+              >
+                <CheckCircle2 v-if="eligibility.is_eligible" class="h-6 w-6 flex-none" />
+                <XCircle v-else class="h-6 w-6 flex-none" />
+                <div>
+                  <p class="font-semibold">
+                    {{ eligibility.is_eligible ? 'Elegible para una nueva entrega' : 'Cobertura vigente' }}
+                  </p>
+                  <p class="text-sm opacity-90">
+                    <template v-if="eligibility.is_eligible">Puede programarse una entrega para esta familia.</template>
+                    <template v-else-if="eligibility.days_remaining != null">
+                      Faltan {{ eligibility.days_remaining }} día(s) para una nueva entrega (RN-02).
+                    </template>
+                    <template v-else>La familia tiene una entrega con cobertura activa.</template>
+                  </p>
+                </div>
+              </div>
+              <dl class="mt-4 grid grid-cols-1 gap-4 text-sm sm:grid-cols-2">
+                <div>
+                  <dt class="text-neutral-500">Última entrega</dt>
+                  <dd class="font-medium text-neutral-900">{{ fmtDateTime(eligibility.last_delivery_at) }}</dd>
+                </div>
+                <div>
+                  <dt class="text-neutral-500">Cobertura hasta</dt>
+                  <dd class="font-medium text-neutral-900">{{ fmtDateTime(eligibility.coverage_expires) }}</dd>
+                </div>
+                <div v-if="!eligibility.is_eligible">
+                  <dt class="text-neutral-500">Próxima elegibilidad</dt>
+                  <dd class="font-medium text-neutral-900">{{ fmtDateTime(eligibility.next_eligible_at) }}</dd>
+                </div>
+              </dl>
+            </div>
+          </div>
+        </div>
+      </div>
+    </template>
+
+    <!-- Modal crear / editar persona -->
+    <BaseModal
+      :open="personModalOpen"
+      :title="personEditId != null ? 'Editar integrante' : 'Agregar integrante'"
+      max-width="max-w-[600px]"
+      @close="personModalOpen = false"
     >
-      <template #actions>
-        <AppButton variant="outline" @click="router.push('/families')">
-          <ArrowLeft /> Volver
+      <form class="space-y-4" @submit.prevent="submitPerson">
+        <FormField label="Nombre completo" required :error="personErrors.name" input-id="pe-name">
+          <input id="pe-name" v-model="personForm.name" class="control" placeholder="Nombre y apellidos" />
+        </FormField>
+
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <FormField label="Documento" required :error="personErrors.document" input-id="pe-doc">
+            <input id="pe-doc" v-model="personForm.document" class="control" placeholder="Documento de identidad" />
+          </FormField>
+          <FormField label="Fecha de nacimiento" required :error="personErrors.birth_date" input-id="pe-birth">
+            <input id="pe-birth" v-model="personForm.birth_date" type="date" :max="todayStr" class="control" />
+          </FormField>
+        </div>
+
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <SelectField
+            v-model="personForm.gender"
+            label="Sexo"
+            required
+            :options="genderOptions"
+            :error="personErrors.gender"
+            input-id="pe-gender"
+          />
+          <SelectField
+            v-model="personForm.relationship"
+            label="Parentesco"
+            required
+            :options="relationshipOptions"
+            :error="personErrors.relationship"
+            input-id="pe-rel"
+          />
+        </div>
+
+        <FormField label="Condiciones especiales" :error="personErrors.special_conditions">
+          <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            <label
+              v-for="opt in SPECIAL_CONDITION_OPTIONS"
+              :key="opt.value"
+              class="flex cursor-pointer items-center gap-2 rounded-md border border-neutral-200 px-3 py-2 text-sm"
+            >
+              <input
+                type="checkbox"
+                class="h-4 w-4 accent-primary-600"
+                :checked="personForm.special_conditions.includes(opt.value)"
+                @change="toggleCondition(opt.value)"
+              />
+              {{ opt.label }}
+            </label>
+          </div>
+        </FormField>
+
+        <label class="flex cursor-pointer items-center gap-2 text-sm text-neutral-700">
+          <input type="checkbox" v-model="personForm.requires_medication" class="h-4 w-4 accent-primary-600" />
+          Requiere medicación permanente
+        </label>
+      </form>
+
+      <template #footer>
+        <AppButton variant="ghost" @click="personModalOpen = false">Cancelar</AppButton>
+        <AppButton :disabled="personSaving" @click="submitPerson">
+          {{ personSaving ? 'Guardando…' : personEditId != null ? 'Guardar' : 'Agregar' }}
         </AppButton>
       </template>
-    </PageHeader>
-    <div class="rounded-lg border border-neutral-200 bg-white p-8 text-center text-sm text-neutral-500">
-      Detalle de la familia #{{ route.params.id }} — en construcción.
-    </div>
+    </BaseModal>
+
+    <!-- Confirmar eliminación de persona -->
+    <ConfirmDialog
+      :open="personConfirmOpen"
+      title="Eliminar integrante"
+      :message="personTarget ? `¿Eliminar a “${personTarget.name}” del núcleo familiar?` : ''"
+      confirm-label="Eliminar"
+      @confirm="confirmDeletePerson"
+      @close="personConfirmOpen = false"
+    />
+
+    <!-- Confirmar eliminación de familia -->
+    <ConfirmDialog
+      :open="familyConfirmOpen"
+      title="Eliminar familia"
+      :message="family ? `¿Eliminar la familia ${family.family_code}? Esta acción no se puede deshacer.` : ''"
+      confirm-label="Eliminar"
+      @confirm="confirmDeleteFamily"
+      @close="familyConfirmOpen = false"
+    />
   </section>
 </template>

--- a/client/src/pages/families/FamilyFormPage.vue
+++ b/client/src/pages/families/FamilyFormPage.vue
@@ -1,27 +1,348 @@
 <script setup lang="ts">
-import { useRouter } from 'vue-router'
-import { ArrowLeft } from '@lucide/vue'
-import AppButton from '@/components/ui/AppButton.vue'
+import { computed, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { toast } from 'vue-sonner'
+import { ArrowLeft, Save, Info } from '@lucide/vue'
+import { useZones } from '@/composables/useZones'
+import { useShelters } from '@/composables/useShelters'
+import { useFamily, useFamilyMutations } from '@/composables/useFamilies'
+import { FAMILY_STATUS_OPTIONS } from '@/types/family.types'
+import type { FamilyCreatePayload, FamilyStatus, FamilyUpdatePayload } from '@/types/family.types'
+import { familyCreateSchema, familyEditSchema } from '@/schemas/family.schema'
+import { validate } from '@/utils/validation'
+import { apiErrorMessage } from '@/utils/apiError'
 import PageHeader from '@/components/ui/PageHeader.vue'
+import AppButton from '@/components/ui/AppButton.vue'
+import SkeletonBlock from '@/components/ui/SkeletonBlock.vue'
+import FormField from '@/components/form/FormField.vue'
+import SelectField from '@/components/form/SelectField.vue'
+import MapPicker from '@/components/form/MapPicker.vue'
+import PrivacyConsentCheckbox from '@/components/form/PrivacyConsentCheckbox.vue'
 
+const route = useRoute()
 const router = useRouter()
+
+const isEdit = computed(() => route.name === 'family-edit')
+const familyId = computed(() => (isEdit.value ? Number(route.params.id) : 0))
+
+const { data: family, isLoading: loadingFamily, isError: familyError } = useFamily(familyId)
+const { data: zones } = useZones()
+const { data: shelters } = useShelters()
+const { create, update } = useFamilyMutations()
+const saving = computed(() => create.isPending.value || update.isPending.value)
+
+// Clave de idempotencia estable por instancia del formulario: un reintento de un
+// alta (corte de red / cola offline) deduplica en el backend (HU-04 CA5).
+const clientOpId = ref(crypto.randomUUID())
+
+const zoneOptions = computed(() => [
+  { value: '', label: 'Selecciona la zona…' },
+  ...(zones.value ?? []).map((z) => ({ value: String(z.id), label: z.name })),
+])
+const shelterOptions = computed(() => [
+  { value: '', label: 'Sin refugio asignado' },
+  ...(shelters.value ?? []).map((s) => ({ value: String(s.id), label: s.name })),
+])
+const statusOptions = FAMILY_STATUS_OPTIONS.map((s) => ({ value: s.value as string, label: s.label }))
+
+function blankForm() {
+  return {
+    head_document: '',
+    zone_id: '',
+    shelter_id: '',
+    status: 'ACTIVO' as FamilyStatus,
+    reference_address: '',
+    num_members: '',
+    num_children_under_5: '',
+    num_adults_over_65: '',
+    num_pregnant: '',
+    num_disabled: '',
+    latitude: null as number | null,
+    longitude: null as number | null,
+  }
+}
+const form = ref(blankForm())
+const consent = ref(false)
+const errors = ref<Record<string, string>>({})
+
+// En edición, precarga el formulario con la familia cargada.
+watch(
+  family,
+  (f) => {
+    if (!f) return
+    form.value = {
+      head_document: f.head_document,
+      zone_id: String(f.zone_id),
+      shelter_id: f.shelter_id != null ? String(f.shelter_id) : '',
+      status: f.status,
+      reference_address: f.reference_address ?? '',
+      num_members: String(f.num_members),
+      num_children_under_5: String(f.num_children_under_5),
+      num_adults_over_65: String(f.num_adults_over_65),
+      num_pregnant: String(f.num_pregnant),
+      num_disabled: String(f.num_disabled),
+      latitude: f.latitude,
+      longitude: f.longitude,
+    }
+  },
+  { immediate: true },
+)
+
+function clearLocation() {
+  form.value.latitude = null
+  form.value.longitude = null
+}
+
+async function submit() {
+  errors.value = {}
+
+  if (isEdit.value) {
+    const res = validate(familyEditSchema, {
+      head_document: form.value.head_document,
+      zone_id: form.value.zone_id,
+      shelter_id: form.value.shelter_id,
+      status: form.value.status,
+      reference_address: form.value.reference_address,
+    })
+    if (!res.ok) {
+      errors.value = res.errors
+      return
+    }
+    const payload: FamilyUpdatePayload = {
+      head_document: res.data.head_document,
+      zone_id: res.data.zone_id,
+      shelter_id: res.data.shelter_id,
+      status: res.data.status,
+      reference_address: res.data.reference_address?.trim() ? res.data.reference_address : null,
+      latitude: form.value.latitude,
+      longitude: form.value.longitude,
+    }
+    try {
+      await update.mutateAsync({ id: familyId.value, payload })
+      toast.success('Familia actualizada')
+      router.push(`/families/${familyId.value}`)
+    } catch (e) {
+      toast.error(apiErrorMessage(e))
+    }
+    return
+  }
+
+  // Alta.
+  const res = validate(familyCreateSchema, {
+    head_document: form.value.head_document,
+    zone_id: form.value.zone_id,
+    shelter_id: form.value.shelter_id,
+    status: form.value.status,
+    reference_address: form.value.reference_address,
+    num_members: form.value.num_members,
+    num_children_under_5: form.value.num_children_under_5,
+    num_adults_over_65: form.value.num_adults_over_65,
+    num_pregnant: form.value.num_pregnant,
+    num_disabled: form.value.num_disabled,
+    privacy_consent_accepted: consent.value,
+  })
+  if (!res.ok) {
+    errors.value = res.errors
+    return
+  }
+  const payload: FamilyCreatePayload = {
+    head_document: res.data.head_document,
+    zone_id: res.data.zone_id,
+    shelter_id: res.data.shelter_id,
+    num_members: res.data.num_members,
+    num_children_under_5: res.data.num_children_under_5,
+    num_adults_over_65: res.data.num_adults_over_65,
+    num_pregnant: res.data.num_pregnant,
+    num_disabled: res.data.num_disabled,
+    status: res.data.status,
+    reference_address: res.data.reference_address?.trim() ? res.data.reference_address : null,
+    latitude: form.value.latitude,
+    longitude: form.value.longitude,
+    privacy_consent_accepted: true,
+  }
+  try {
+    const created = await create.mutateAsync({ payload, clientOpId: clientOpId.value })
+    toast.success(`Familia ${created.family_code} registrada`)
+    router.push(`/families/${created.id}`)
+  } catch (e) {
+    toast.error(apiErrorMessage(e, 'No se pudo registrar la familia. ¿El documento ya existe?'))
+  }
+}
 </script>
 
 <template>
-  <section class="space-y-5">
+  <section class="mx-auto max-w-3xl space-y-5">
     <PageHeader
-      title="Registrar familia"
+      :title="isEdit ? 'Editar familia' : 'Registrar familia'"
       crumb="Censo"
-      subtitle="Pantalla pendiente (HU-04: censo offline + consentimiento Ley 1581)"
+      :subtitle="
+        isEdit
+          ? 'Actualiza los datos del núcleo familiar'
+          : 'Censo del núcleo familiar (Ley 1581/2012)'
+      "
     >
       <template #actions>
-        <AppButton variant="outline" @click="router.push('/families')">
+        <AppButton variant="outline" @click="router.push(isEdit ? `/families/${familyId}` : '/families')">
           <ArrowLeft /> Volver
         </AppButton>
       </template>
     </PageHeader>
-    <div class="rounded-lg border border-neutral-200 bg-white p-8 text-center text-sm text-neutral-500">
-      Formulario de censo — en construcción (HU-04).
+
+    <!-- Estados de carga / error en edición -->
+    <div v-if="isEdit && loadingFamily" class="space-y-3 rounded-lg border border-neutral-200 bg-white p-6">
+      <SkeletonBlock v-for="n in 6" :key="n" height="48px" />
     </div>
+    <div
+      v-else-if="isEdit && familyError"
+      class="rounded-lg border border-danger-br bg-danger-bg p-6 text-center text-sm text-danger"
+    >
+      No se pudo cargar la familia.
+    </div>
+
+    <form v-else class="space-y-5" @submit.prevent="submit">
+      <!-- Datos básicos -->
+      <fieldset class="space-y-4 rounded-lg border border-neutral-200 bg-white p-5">
+        <legend class="px-1 text-sm font-semibold text-neutral-700">Datos básicos</legend>
+
+        <FormField
+          label="Documento del jefe de hogar"
+          required
+          :error="errors.head_document"
+          input-id="fa-doc"
+          hint="Cédula o documento de identidad del responsable del núcleo."
+        >
+          <input id="fa-doc" v-model="form.head_document" class="control" placeholder="Ej. 1063xxxxxx" />
+        </FormField>
+
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <SelectField
+            v-model="form.zone_id"
+            label="Zona"
+            required
+            :options="zoneOptions"
+            :error="errors.zone_id"
+            input-id="fa-zone"
+          />
+          <SelectField
+            v-model="form.shelter_id"
+            label="Refugio"
+            :options="shelterOptions"
+            :error="errors.shelter_id"
+            input-id="fa-shelter"
+            hint="Opcional: solo si la familia está alojada en un refugio."
+          />
+        </div>
+
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <SelectField
+            v-model="form.status"
+            label="Estado"
+            required
+            :options="statusOptions"
+            :error="errors.status"
+            input-id="fa-status"
+          />
+          <FormField label="Dirección de referencia" :error="errors.reference_address" input-id="fa-addr">
+            <input id="fa-addr" v-model="form.reference_address" class="control" placeholder="Barrio, calle…" />
+          </FormField>
+        </div>
+      </fieldset>
+
+      <!-- Composición -->
+      <fieldset class="space-y-4 rounded-lg border border-neutral-200 bg-white p-5">
+        <legend class="px-1 text-sm font-semibold text-neutral-700">Composición familiar</legend>
+
+        <template v-if="!isEdit">
+          <FormField
+            label="Total de integrantes"
+            required
+            :error="errors.num_members"
+            input-id="fa-members"
+            hint="Personas que componen el núcleo familiar."
+          >
+            <input id="fa-members" v-model="form.num_members" type="number" min="1" class="control" placeholder="0" />
+          </FormField>
+
+          <div class="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            <FormField label="Niños < 5" :error="errors.num_children_under_5" input-id="fa-c5">
+              <input id="fa-c5" v-model="form.num_children_under_5" type="number" min="0" class="control" placeholder="0" />
+            </FormField>
+            <FormField label="Adultos > 65" :error="errors.num_adults_over_65" input-id="fa-a65">
+              <input id="fa-a65" v-model="form.num_adults_over_65" type="number" min="0" class="control" placeholder="0" />
+            </FormField>
+            <FormField label="Gestantes" :error="errors.num_pregnant" input-id="fa-preg">
+              <input id="fa-preg" v-model="form.num_pregnant" type="number" min="0" class="control" placeholder="0" />
+            </FormField>
+            <FormField label="Discapacidad" :error="errors.num_disabled" input-id="fa-dis">
+              <input id="fa-dis" v-model="form.num_disabled" type="number" min="0" class="control" placeholder="0" />
+            </FormField>
+          </div>
+        </template>
+
+        <!-- En edición, la composición se deriva de las personas (#14): solo lectura. -->
+        <div v-else class="space-y-3">
+          <div class="flex items-start gap-2 rounded-md bg-primary-50 p-3 text-sm text-primary-800">
+            <Info class="mt-0.5 h-4 w-4 flex-none" />
+            <span>
+              La composición se calcula a partir de los integrantes registrados. Para modificarla,
+              gestiona los miembros desde el detalle de la familia.
+            </span>
+          </div>
+          <div class="grid grid-cols-2 gap-3 sm:grid-cols-5">
+            <div v-for="c in [
+              { label: 'Integrantes', value: form.num_members },
+              { label: 'Niños < 5', value: form.num_children_under_5 },
+              { label: 'Adultos > 65', value: form.num_adults_over_65 },
+              { label: 'Gestantes', value: form.num_pregnant },
+              { label: 'Discapacidad', value: form.num_disabled },
+            ]" :key="c.label" class="rounded-md border border-neutral-200 bg-neutral-50 p-3 text-center">
+              <p class="text-lg font-bold text-neutral-900">{{ c.value || 0 }}</p>
+              <p class="text-xs text-neutral-500">{{ c.label }}</p>
+            </div>
+          </div>
+        </div>
+      </fieldset>
+
+      <!-- Ubicación (opcional) -->
+      <fieldset class="space-y-3 rounded-lg border border-neutral-200 bg-white p-5">
+        <legend class="px-1 text-sm font-semibold text-neutral-700">Ubicación (opcional)</legend>
+        <div class="flex items-center justify-between">
+          <p class="text-sm text-neutral-500">
+            Toca el mapa para ubicar el hogar; arrastra el marcador para ajustar.
+          </p>
+          <AppButton
+            v-if="form.latitude != null"
+            type="button"
+            variant="ghost"
+            size="sm"
+            @click="clearLocation"
+          >
+            Quitar ubicación
+          </AppButton>
+        </div>
+        <MapPicker v-model:latitude="form.latitude" v-model:longitude="form.longitude" height="260px" />
+        <p v-if="form.latitude != null" class="font-mono text-xs text-neutral-500">
+          {{ form.latitude?.toFixed(6) }}, {{ form.longitude?.toFixed(6) }}
+        </p>
+      </fieldset>
+
+      <!-- Consentimiento (solo alta, RN-09) -->
+      <div v-if="!isEdit" class="space-y-1">
+        <PrivacyConsentCheckbox v-model="consent" />
+        <p v-if="errors.privacy_consent_accepted" class="flex items-center gap-1.5 text-sm text-danger">
+          {{ errors.privacy_consent_accepted }}
+        </p>
+      </div>
+
+      <!-- Acciones -->
+      <div class="flex items-center justify-end gap-3 pb-4">
+        <AppButton variant="ghost" type="button" @click="router.push(isEdit ? `/families/${familyId}` : '/families')">
+          Cancelar
+        </AppButton>
+        <AppButton type="submit" :disabled="saving || (!isEdit && !consent)">
+          <Save /> {{ saving ? 'Guardando…' : isEdit ? 'Guardar cambios' : 'Registrar familia' }}
+        </AppButton>
+      </div>
+    </form>
   </section>
 </template>

--- a/client/src/pages/persons/PersonSearchPage.vue
+++ b/client/src/pages/persons/PersonSearchPage.vue
@@ -1,0 +1,160 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { Search, UserSearch, Pill, ArrowRight } from '@lucide/vue'
+import { usePersonSearch } from '@/composables/usePersons'
+import { useZones } from '@/composables/useZones'
+import {
+  GENDER_LABELS, RELATIONSHIP_LABELS, SPECIAL_CONDITION_LABELS, ageFromBirthDate,
+} from '@/types/person.types'
+import { apiErrorStatus } from '@/utils/apiError'
+import PageHeader from '@/components/ui/PageHeader.vue'
+import AppButton from '@/components/ui/AppButton.vue'
+import FormField from '@/components/form/FormField.vue'
+import SkeletonBlock from '@/components/ui/SkeletonBlock.vue'
+import EmptyState from '@/components/ui/EmptyState.vue'
+import FamilyStatusBadge from '@/components/ui/FamilyStatusBadge.vue'
+
+const router = useRouter()
+const input = ref('')
+const term = ref('')
+const inputError = ref('')
+
+const { data, isLoading, isError, error } = usePersonSearch(term)
+const { data: zones } = useZones()
+
+const person = computed(() => data.value?.person)
+const family = computed(() => data.value?.family)
+const zoneName = computed(() =>
+  family.value ? ((zones.value ?? []).find((z) => z.id === family.value!.zone_id)?.name ?? '—') : '—',
+)
+const notFound = computed(() => isError.value && apiErrorStatus(error.value) === 404)
+
+function submit() {
+  const v = input.value.trim()
+  if (v.length < 3) {
+    inputError.value = 'Ingresa al menos 3 caracteres del documento.'
+    return
+  }
+  inputError.value = ''
+  term.value = v
+}
+
+function ageLabel(birth: string) {
+  const a = ageFromBirthDate(birth)
+  return a <= 0 ? '< 1 año' : `${a} años`
+}
+</script>
+
+<template>
+  <section class="mx-auto max-w-2xl space-y-5">
+    <PageHeader
+      title="Búsqueda de personas"
+      crumb="Censo"
+      subtitle="Localiza a una persona por su número de documento (HU-06)"
+    />
+
+    <form class="flex items-end gap-3 rounded-lg border border-neutral-200 bg-white p-4" @submit.prevent="submit">
+      <div class="flex-1">
+        <FormField label="Documento de identidad" :error="inputError" input-id="ps-doc">
+          <input
+            id="ps-doc"
+            v-model="input"
+            class="control"
+            placeholder="Ej. 1063xxxxxx"
+            autofocus
+          />
+        </FormField>
+      </div>
+      <AppButton type="submit" class="mb-0.5"><Search /> Buscar</AppButton>
+    </form>
+
+    <!-- Estado inicial -->
+    <div v-if="!term" class="rounded-lg border border-neutral-200 bg-white">
+      <EmptyState title="Busca a una persona" message="Escribe el documento y presiona Buscar para ver sus datos y su familia.">
+        <template #icon><UserSearch /></template>
+      </EmptyState>
+    </div>
+
+    <!-- Cargando -->
+    <div v-else-if="isLoading" class="space-y-3 rounded-lg border border-neutral-200 bg-white p-5">
+      <SkeletonBlock height="28px" />
+      <SkeletonBlock height="80px" />
+    </div>
+
+    <!-- No encontrado -->
+    <div v-else-if="notFound" class="rounded-lg border border-neutral-200 bg-white">
+      <EmptyState title="Sin resultados" :message="`No se encontró ninguna persona con el documento «${term}».`">
+        <template #icon><UserSearch /></template>
+      </EmptyState>
+    </div>
+
+    <!-- Otro error -->
+    <div v-else-if="isError" class="rounded-lg border border-danger-br bg-danger-bg p-6 text-center text-sm text-danger">
+      Ocurrió un error al realizar la búsqueda. Intenta de nuevo.
+    </div>
+
+    <!-- Resultado -->
+    <div v-else-if="person && family" class="space-y-4">
+      <div class="rounded-lg border border-neutral-200 bg-white p-5">
+        <div class="flex items-start justify-between gap-3">
+          <div>
+            <h2 class="text-lg font-bold text-neutral-900">{{ person.name }}</h2>
+            <p class="font-mono text-sm text-neutral-500">{{ person.document }}</p>
+          </div>
+          <span
+            v-if="person.requires_medication"
+            class="inline-flex items-center gap-1 rounded-full bg-warning-bg px-2.5 py-1 text-xs font-semibold text-warning"
+          >
+            <Pill class="h-3.5 w-3.5" /> Requiere medicación
+          </span>
+        </div>
+
+        <dl class="mt-4 grid grid-cols-2 gap-4 text-sm sm:grid-cols-3">
+          <div>
+            <dt class="text-neutral-500">Edad</dt>
+            <dd class="font-medium text-neutral-900">{{ ageLabel(person.birth_date) }}</dd>
+          </div>
+          <div>
+            <dt class="text-neutral-500">Sexo</dt>
+            <dd class="font-medium text-neutral-900">{{ GENDER_LABELS[person.gender] }}</dd>
+          </div>
+          <div>
+            <dt class="text-neutral-500">Parentesco</dt>
+            <dd class="font-medium text-neutral-900">{{ RELATIONSHIP_LABELS[person.relationship] }}</dd>
+          </div>
+        </dl>
+
+        <div v-if="person.special_conditions.length" class="mt-4 flex flex-wrap gap-1.5">
+          <span
+            v-for="c in person.special_conditions"
+            :key="c"
+            class="rounded-full bg-info-bg px-2.5 py-1 text-xs text-primary-700"
+          >
+            {{ SPECIAL_CONDITION_LABELS[c] }}
+          </span>
+        </div>
+      </div>
+
+      <!-- Familia asociada -->
+      <div class="rounded-lg border border-neutral-200 bg-white p-5">
+        <h3 class="mb-3 text-sm font-semibold text-neutral-700">Familia asociada</h3>
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <div class="space-y-1">
+            <div class="flex items-center gap-2">
+              <span class="font-mono font-semibold text-neutral-900">{{ family.family_code }}</span>
+              <FamilyStatusBadge :status="family.status" />
+            </div>
+            <p class="text-sm text-neutral-500">
+              Jefe de hogar: <span class="font-mono">{{ family.head_document }}</span> ·
+              {{ family.num_members }} integrante(s) · {{ zoneName }}
+            </p>
+          </div>
+          <AppButton variant="outline" size="sm" @click="router.push(`/families/${family.id}`)">
+            Ver familia <ArrowRight />
+          </AppButton>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -36,11 +36,24 @@ const router = createRouter({
           path: 'families/new',
           name: 'family-new',
           component: () => import('@/pages/families/FamilyFormPage.vue'),
+          meta: { roles: ['ADMIN', 'COORDINADOR_LOGISTICA', 'CENSADOR'] },
         },
         {
           path: 'families/:id',
           name: 'family-detail',
           component: () => import('@/pages/families/FamilyDetailPage.vue'),
+        },
+        {
+          path: 'families/:id/edit',
+          name: 'family-edit',
+          component: () => import('@/pages/families/FamilyFormPage.vue'),
+          meta: { roles: ['ADMIN', 'COORDINADOR_LOGISTICA', 'CENSADOR'] },
+        },
+        // Búsqueda de personas por documento (HU-06).
+        {
+          path: 'persons/search',
+          name: 'person-search',
+          component: () => import('@/pages/persons/PersonSearchPage.vue'),
         },
         // Zonas (HU-09) y Refugios (HU-10): CRUD restringido a ADMIN/COORDINADOR.
         {

--- a/client/src/schemas/family.schema.ts
+++ b/client/src/schemas/family.schema.ts
@@ -1,0 +1,81 @@
+import { z } from 'zod'
+
+// Campos núcleo de la familia, editables tanto al crear como al actualizar.
+// La ubicación (lat/lng) es opcional para familias y se maneja aparte (MapPicker).
+const coreShape = {
+  head_document: z
+    .string()
+    .trim()
+    .min(5, 'Mínimo 5 caracteres')
+    .max(30, 'Máximo 30 caracteres'),
+  zone_id: z.preprocess(
+    (v) => (v === '' || v === null || v === undefined ? undefined : Number(v)),
+    z.number({ message: 'Selecciona la zona' }).int().min(1, 'Selecciona la zona'),
+  ),
+  shelter_id: z.preprocess(
+    (v) => (v === '' || v === null || v === undefined ? null : Number(v)),
+    z.number().int().min(1).nullable(),
+  ),
+  status: z.enum(['ACTIVO', 'EN_REFUGIO', 'EVACUADO'], {
+    message: 'Selecciona el estado',
+  }),
+  reference_address: z.string().trim().max(250, 'Máximo 250 caracteres').optional(),
+}
+
+// Conteos de composición (solo en el alta; en edición se derivan de las personas).
+// Cada conteo no puede superar el total de miembros.
+const compositionShape = {
+  num_members: z.preprocess(
+    (v) => (v === '' || v === null || v === undefined ? undefined : Number(v)),
+    z.number({ message: 'Ingresa el número de integrantes' }).int('Debe ser un entero').min(1, 'Al menos 1'),
+  ),
+  num_children_under_5: z.preprocess(
+    (v) => (v === '' || v === null || v === undefined ? 0 : Number(v)),
+    z.number().int('Debe ser un entero').min(0, 'No puede ser negativo'),
+  ),
+  num_adults_over_65: z.preprocess(
+    (v) => (v === '' || v === null || v === undefined ? 0 : Number(v)),
+    z.number().int('Debe ser un entero').min(0, 'No puede ser negativo'),
+  ),
+  num_pregnant: z.preprocess(
+    (v) => (v === '' || v === null || v === undefined ? 0 : Number(v)),
+    z.number().int('Debe ser un entero').min(0, 'No puede ser negativo'),
+  ),
+  num_disabled: z.preprocess(
+    (v) => (v === '' || v === null || v === undefined ? 0 : Number(v)),
+    z.number().int('Debe ser un entero').min(0, 'No puede ser negativo'),
+  ),
+}
+
+export const familyEditSchema = z.object(coreShape)
+
+// Alta: núcleo + composición + consentimiento obligatorio (RN-09).
+export const familyCreateSchema = z
+  .object({
+    ...coreShape,
+    ...compositionShape,
+    privacy_consent_accepted: z.boolean(),
+  })
+  .refine((d) => d.num_children_under_5 <= d.num_members, {
+    path: ['num_children_under_5'],
+    message: 'No puede superar el total de integrantes',
+  })
+  .refine((d) => d.num_adults_over_65 <= d.num_members, {
+    path: ['num_adults_over_65'],
+    message: 'No puede superar el total de integrantes',
+  })
+  .refine((d) => d.num_pregnant <= d.num_members, {
+    path: ['num_pregnant'],
+    message: 'No puede superar el total de integrantes',
+  })
+  .refine((d) => d.num_disabled <= d.num_members, {
+    path: ['num_disabled'],
+    message: 'No puede superar el total de integrantes',
+  })
+  .refine((d) => d.privacy_consent_accepted === true, {
+    path: ['privacy_consent_accepted'],
+    message: 'Debe aceptar el aviso de privacidad (Ley 1581/2012) para registrar la familia',
+  })
+
+export type FamilyCreateValues = z.infer<typeof familyCreateSchema>
+export type FamilyEditValues = z.infer<typeof familyEditSchema>

--- a/client/src/schemas/person.schema.ts
+++ b/client/src/schemas/person.schema.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod'
+
+// Campos del formulario de persona (integrante de familia). Refleja POST /persons.
+export const personSchema = z.object({
+  name: z.string().trim().min(2, 'Mínimo 2 caracteres').max(120, 'Máximo 120 caracteres'),
+  document: z.string().trim().min(5, 'Mínimo 5 caracteres').max(30, 'Máximo 30 caracteres'),
+  birth_date: z
+    .string()
+    .min(1, 'Ingresa la fecha de nacimiento')
+    .refine((v) => !Number.isNaN(new Date(v).getTime()), 'Fecha inválida')
+    .refine((v) => new Date(v) <= new Date(), 'La fecha no puede ser futura'),
+  gender: z.enum(['M', 'F', 'OTRO'], { message: 'Selecciona el sexo' }),
+  relationship: z.enum(['ESPOSO_A', 'HIJO_A', 'PADRE_MADRE', 'HERMANO_A', 'OTRO'], {
+    message: 'Selecciona el parentesco',
+  }),
+  special_conditions: z
+    .array(z.enum(['CHILD_UNDER_5', 'ELDERLY_OVER_65', 'PREGNANT', 'DISABLED']))
+    .default([]),
+  requires_medication: z.boolean().default(false),
+})
+
+export type PersonFormValues = z.infer<typeof personSchema>

--- a/client/src/types/delivery.types.ts
+++ b/client/src/types/delivery.types.ts
@@ -1,0 +1,49 @@
+// Tipos del módulo de entregas. Por ahora solo lo necesario para el historial de
+// entregas de una familia (HU-08); el módulo de Entregas (paso 9) lo ampliará.
+
+export type DeliveryStatus = 'PROGRAMADA' | 'EN_CURSO' | 'ENTREGADA'
+
+export const DELIVERY_STATUS_LABELS: Record<DeliveryStatus, string> = {
+  PROGRAMADA: 'Programada',
+  EN_CURSO: 'En curso',
+  ENTREGADA: 'Entregada',
+}
+
+// Color del badge por estado (gris · azul · verde, FRONTEND-PLAN §3.7).
+export const DELIVERY_STATUS_COLOR: Record<DeliveryStatus, 'slate' | 'blue' | 'green'> = {
+  PROGRAMADA: 'slate',
+  EN_CURSO: 'blue',
+  ENTREGADA: 'green',
+}
+
+export interface DeliveryDetail {
+  id: number
+  resource_type_id: number
+  resource_name: string
+  category: string
+  quantity: number
+  weight_kg: number
+  batch: string | null
+}
+
+export interface Delivery {
+  id: number
+  delivery_code: string
+  family_id: number
+  source_warehouse_id: number
+  plan_item_id: number | null
+  delivery_date: string
+  delivered_by: number | null
+  received_by_document: string | null
+  coverage_days: number
+  status: DeliveryStatus
+  delivery_latitude: number | null
+  delivery_longitude: number | null
+  exception_reason: string | null
+  exception_authorized_by: number | null
+  client_op_id: string | null
+  notes: string | null
+  created_at: string
+  updated_at: string
+  details?: DeliveryDetail[]
+}

--- a/client/src/types/family.types.ts
+++ b/client/src/types/family.types.ts
@@ -38,3 +38,70 @@ export interface FamilyListParams {
   status?: FamilyStatus
   order_by?: FamilyOrderBy
 }
+
+// Cuerpo de POST /families. El consentimiento de privacidad es obligatorio y
+// debe ser true (RN-09, Ley 1581/2012). En el alta se aceptan los conteos de
+// composición agregados (censo rápido HU-04); luego se derivan de las personas.
+export interface FamilyCreatePayload {
+  head_document: string
+  zone_id: number
+  shelter_id: number | null
+  num_members: number
+  num_children_under_5: number
+  num_adults_over_65: number
+  num_pregnant: number
+  num_disabled: number
+  status: FamilyStatus
+  latitude: number | null
+  longitude: number | null
+  reference_address: string | null
+  privacy_consent_accepted: true
+}
+
+// Cuerpo de PUT /families/:id. No incluye num_members ni los conteos: esos se
+// recalculan desde las personas (#14) y se gestionan en la pestaña Miembros.
+export interface FamilyUpdatePayload {
+  head_document?: string
+  zone_id?: number
+  shelter_id?: number | null
+  status?: FamilyStatus
+  latitude?: number | null
+  longitude?: number | null
+  reference_address?: string | null
+}
+
+// GET /families/:id/eligibility (RN-02, HU-23). Misma forma que la elegibilidad
+// de entregas: indica si la familia puede recibir una nueva entrega.
+export interface FamilyEligibility {
+  is_eligible: boolean
+  reason: string
+  last_delivery_at: string | null
+  coverage_expires: string | null
+  days_remaining: number | null
+  next_eligible_at: string | null
+}
+
+// Forma del priority_score_breakdown que produce fn_priority_score: una
+// contribución por factor (puntos) + inputs/weights crudos (HU-08 CA2).
+export interface FamilyScoreBreakdown {
+  members: number
+  children_u5: number
+  adults_o65: number
+  pregnant: number
+  disabled: number
+  zone_risk: number
+  days_no_aid: number
+  deliveries: number
+  inputs: {
+    num_members: number
+    num_children_under_5: number
+    num_adults_over_65: number
+    num_pregnant: number
+    num_disabled: number
+    zone_risk_factor: number
+    days_without_aid: number
+    deliveries_received: number
+    max_days: number
+  }
+  weights: Record<string, number>
+}

--- a/client/src/types/person.types.ts
+++ b/client/src/types/person.types.ts
@@ -1,0 +1,98 @@
+// Tipos del módulo de personas (integrantes de familia). Reflejan el contrato del
+// backend (server/src/types/entities.ts): enums Gender / Relationship /
+// SpecialCondition y la forma de POST/PUT /persons.
+
+import type { FamilyStatus } from './family.types'
+
+export type Gender = 'M' | 'F' | 'OTRO'
+
+export const GENDER_OPTIONS: { value: Gender; label: string }[] = [
+  { value: 'M', label: 'Masculino' },
+  { value: 'F', label: 'Femenino' },
+  { value: 'OTRO', label: 'Otro' },
+]
+
+export const GENDER_LABELS = Object.fromEntries(
+  GENDER_OPTIONS.map((o) => [o.value, o.label]),
+) as Record<Gender, string>
+
+export type Relationship = 'ESPOSO_A' | 'HIJO_A' | 'PADRE_MADRE' | 'HERMANO_A' | 'OTRO'
+
+export const RELATIONSHIP_OPTIONS: { value: Relationship; label: string }[] = [
+  { value: 'ESPOSO_A', label: 'Cónyuge' },
+  { value: 'HIJO_A', label: 'Hijo/a' },
+  { value: 'PADRE_MADRE', label: 'Padre/Madre' },
+  { value: 'HERMANO_A', label: 'Hermano/a' },
+  { value: 'OTRO', label: 'Otro' },
+]
+
+export const RELATIONSHIP_LABELS = Object.fromEntries(
+  RELATIONSHIP_OPTIONS.map((o) => [o.value, o.label]),
+) as Record<Relationship, string>
+
+// El backend dejó REQUIRES_MEDICATION fuera del enum: el requerimiento de
+// medicación va por el booleano `requires_medication`, no por este arreglo.
+export type SpecialCondition = 'CHILD_UNDER_5' | 'ELDERLY_OVER_65' | 'PREGNANT' | 'DISABLED'
+
+export const SPECIAL_CONDITION_OPTIONS: { value: SpecialCondition; label: string }[] = [
+  { value: 'CHILD_UNDER_5', label: 'Menor de 5 años' },
+  { value: 'ELDERLY_OVER_65', label: 'Mayor de 65 años' },
+  { value: 'PREGNANT', label: 'Gestante' },
+  { value: 'DISABLED', label: 'En situación de discapacidad' },
+]
+
+export const SPECIAL_CONDITION_LABELS = Object.fromEntries(
+  SPECIAL_CONDITION_OPTIONS.map((o) => [o.value, o.label]),
+) as Record<SpecialCondition, string>
+
+export interface Person {
+  id: number
+  family_id: number
+  name: string
+  document: string
+  birth_date: string // pg DATE → 'YYYY-MM-DD'
+  gender: Gender
+  relationship: Relationship
+  special_conditions: SpecialCondition[]
+  requires_medication: boolean
+  created_at: string
+  updated_at: string
+}
+
+// Cuerpo de POST /persons. En PUT, todos los campos salvo family_id son opcionales
+// (family_id no se reasigna al editar).
+export interface PersonPayload {
+  family_id: number
+  name: string
+  document: string
+  birth_date: string
+  gender: Gender
+  relationship: Relationship
+  special_conditions: SpecialCondition[]
+  requires_medication: boolean
+}
+
+// GET /persons/search?document= devuelve la persona junto a su familia.
+export interface PersonWithFamily {
+  person: Person
+  family: {
+    id: number
+    family_code: string
+    head_document: string
+    zone_id: number
+    shelter_id: number | null
+    num_members: number
+    status: FamilyStatus
+  }
+}
+
+// Edad en años cumplidos a partir de la fecha de nacimiento 'YYYY-MM-DD'.
+export function ageFromBirthDate(birthDate: string): number {
+  const birth = new Date(birthDate)
+  if (Number.isNaN(birth.getTime())) return 0
+  const now = new Date()
+  let age = now.getFullYear() - birth.getFullYear()
+  const m = now.getMonth() - birth.getMonth()
+  if (m < 0 || (m === 0 && now.getDate() < birth.getDate())) age--
+  return age
+}


### PR DESCRIPTION
## Paso 5 del frontend (Vue): Familias + Personas

Rellena los dos stubs de familias (`FamilyFormPage`, `FamilyDetailPage`) y añade la búsqueda de personas, siguiendo el patrón establecido en el cliente (api + composable + types + schema Zod + UI kit + `RoleGate`).

### Pantallas
- **FamilyFormPage** (HU-04 / HU-05): alta y edición de familia. Consentimiento Ley 1581/2012 **obligatorio (RN-09)** que bloquea el envío; composición editable en el alta y solo-lectura en edición (el backend la deriva de las personas, #14); ubicación opcional con `MapPicker`; `Idempotency-Key` cableado para la cola offline (Paso 15).
- **FamilyDetailPage** (HU-07 / HU-08): tarjeta de **Puntaje con desglose por factor** (`ScoreBreakdown`), pestañas **Miembros** (CRUD de personas inline → recalcula conteos y puntaje), **Entregas** (historial) y **Elegibilidad** (RN-02); mini-mapa si hay coordenadas.
- **PersonSearchPage** (HU-06): búsqueda exacta por documento → persona + familia asociada (con manejo de 404).

### Soporte
- `types/person.types.ts`, `types/delivery.types.ts`; payloads, elegibilidad y tipo del breakdown en `family.types.ts`.
- `schemas/family.schema.ts`, `schemas/person.schema.ts` (Zod).
- `api/persons.api.ts` + extensión de `families.api.ts`; `composables/usePersons.ts` + extensión de `useFamilies.ts`.
- Rutas `families/:id/edit` y `persons/search` (con `meta.roles`); item "Buscar Personas" en el sidebar.

### Verificación
- ✅ `pnpm -C client typecheck` (vue-tsc)
- ✅ `pnpm -C client build` (vue-tsc + vite)

### Fuera de alcance (pendiente del plan)
- Cola offline real con Dexie (Paso 15) — por ahora solo `Idempotency-Key`.
- `UsersPage` (HU-03), hueco del Paso 3.

> Nota: `pnpm -C client lint` está roto de antes (falta el dep `@eslint/js`), ajeno a este PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)