### PR TITLE
feat(client): Auth completo (Paso 3) — fix login + cambio de contraseña + gestión de usuarios (HU-01/02/03)

### DIFF
--- a/client/src/api/auth.api.ts
+++ b/client/src/api/auth.api.ts
@@ -1,16 +1,55 @@
 import { api } from './axios'
+import type { ApiItem } from '@/types/api.types'
 import type { LoginPayload, LoginResponse, User } from '@/types/auth.types'
+import type {
+  RegisterUserPayload,
+  ResetPasswordResult,
+  UserListItem,
+  UsersListParams,
+  UsersListResponse,
+} from '@/types/user.types'
 
-// Modulo de API de Auth. Patron a replicar en el resto de modulos
-// (families.api.ts, deliveries.api.ts, ...). Endpoints reales: /api/v1/auth/*.
+// Módulo de API de Auth. Endpoints reales: /api/v1/auth/*. El backend envuelve
+// las respuestas en { success, data } → desenvolvemos a .data.data como el resto
+// de la app (familias, refugios…).
 export const authApi = {
+  // Login devuelve SOLO { token }; el perfil se obtiene con /auth/me.
   login(payload: LoginPayload) {
-    return api.post<LoginResponse>('/auth/login', payload).then((r) => r.data)
+    return api.post<ApiItem<LoginResponse>>('/auth/login', payload).then((r) => r.data.data)
   },
   me() {
-    return api.get<User>('/auth/me').then((r) => r.data)
+    return api.get<ApiItem<User>>('/auth/me').then((r) => r.data.data)
   },
-  changePassword(payload: { current_password: string; new_password: string }) {
+  // El backend espera oldPassword / newPassword (auth.validator.ts).
+  changePassword(payload: { oldPassword: string; newPassword: string }) {
     return api.put('/auth/change-password', payload).then((r) => r.data)
+  },
+
+  // --- Gestión de usuarios (solo ADMIN) ---------------------------------------
+
+  // Respuesta plana { success, data, total, page, per_page }; param de tamaño es
+  // per_page (no limit).
+  listUsers(params: UsersListParams) {
+    const query: Record<string, string | number> = { page: params.page, per_page: params.per_page }
+    if (params.role) query.role = params.role
+    if (params.is_active !== undefined) query.is_active = String(params.is_active)
+    return api.get<UsersListResponse>('/auth/users', { params: query }).then((r) => r.data)
+  },
+
+  register(payload: RegisterUserPayload) {
+    return api.post<ApiItem<UserListItem>>('/auth/register', payload).then((r) => r.data.data)
+  },
+
+  setActive(id: number, isActive: boolean) {
+    return api
+      .put<ApiItem<UserListItem>>(`/auth/users/${id}`, { is_active: isActive })
+      .then((r) => r.data.data)
+  },
+
+  // Genera y devuelve una contraseña temporal (se muestra una sola vez).
+  resetPassword(userId: number) {
+    return api
+      .post<ApiItem<ResetPasswordResult>>(`/auth/reset-password/${userId}`, {})
+      .then((r) => r.data.data)
   },
 }

--- a/client/src/composables/useUsers.ts
+++ b/client/src/composables/useUsers.ts
@@ -1,0 +1,35 @@
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/vue-query'
+import type { Ref } from 'vue'
+import { authApi } from '@/api/auth.api'
+import type { RegisterUserPayload, UsersListParams } from '@/types/user.types'
+
+// Listado paginado de usuarios (solo ADMIN). Refetch al cambiar filtros/página.
+export function useUsersList(params: Ref<UsersListParams>) {
+  return useQuery({
+    queryKey: ['users', params],
+    queryFn: () => authApi.listUsers(params.value),
+    placeholderData: keepPreviousData,
+  })
+}
+
+// Mutaciones de gestión de usuarios. resetPassword devuelve la contraseña
+// temporal generada (se muestra una sola vez en la UI).
+export function useUserMutations() {
+  const qc = useQueryClient()
+  const invalidate = () => qc.invalidateQueries({ queryKey: ['users'] })
+
+  const register = useMutation({
+    mutationFn: (payload: RegisterUserPayload) => authApi.register(payload),
+    onSuccess: invalidate,
+  })
+  const setActive = useMutation({
+    mutationFn: ({ id, isActive }: { id: number; isActive: boolean }) => authApi.setActive(id, isActive),
+    onSuccess: invalidate,
+  })
+  const resetPassword = useMutation({
+    mutationFn: (userId: number) => authApi.resetPassword(userId),
+    onSuccess: invalidate,
+  })
+
+  return { register, setActive, resetPassword }
+}

--- a/client/src/pages/auth/ChangePasswordPage.vue
+++ b/client/src/pages/auth/ChangePasswordPage.vue
@@ -1,10 +1,122 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { toast } from 'vue-sonner'
+import { useAuthStore } from '@/stores/auth'
+import { apiErrorMessage, apiErrorStatus } from '@/utils/apiError'
+import SigahLogo from '@/components/SigahLogo.vue'
+import FormField from '@/components/form/FormField.vue'
+import AppButton from '@/components/ui/AppButton.vue'
+
+const auth = useAuthStore()
+const router = useRouter()
+
+const current = ref('')
+const next = ref('')
+const confirm = ref('')
+const errors = ref<Record<string, string>>({})
+const loading = ref(false)
+
+function validate() {
+  const e: Record<string, string> = {}
+  if (!current.value) e.current = 'Ingresa tu contraseña actual.'
+  if (next.value.length < 8) e.next = 'La nueva contraseña debe tener al menos 8 caracteres.'
+  if (confirm.value !== next.value) e.confirm = 'Las contraseñas no coinciden.'
+  if (current.value && next.value && current.value === next.value) {
+    e.next = 'La nueva contraseña debe ser distinta de la actual.'
+  }
+  errors.value = e
+  return Object.keys(e).length === 0
+}
+
+async function onSubmit() {
+  if (!validate()) return
+  loading.value = true
+  try {
+    await auth.changePassword(current.value, next.value)
+    toast.success('Contraseña actualizada')
+    router.push('/dashboard')
+  } catch (err) {
+    if (apiErrorStatus(err) === 401) {
+      errors.value = { current: 'La contraseña actual es incorrecta.' }
+    } else {
+      toast.error(apiErrorMessage(err, 'No se pudo cambiar la contraseña.'))
+    }
+  } finally {
+    loading.value = false
+  }
+}
+
+function onLogout() {
+  auth.logout()
+  router.push('/login')
+}
+</script>
+
 <template>
-  <div class="flex min-h-screen items-center justify-center bg-slate-100 p-4">
-    <div class="w-full max-w-sm rounded-xl border border-slate-200 bg-white p-6 text-center">
-      <h1 class="text-xl font-semibold text-slate-900">Cambiar contrasena</h1>
-      <p class="mt-2 text-sm text-slate-500">
-        Pantalla pendiente (HU-03): obligatoria cuando password_must_change = true.
+  <div class="flex min-h-screen items-center justify-center bg-neutral-100 p-4">
+    <div class="w-full max-w-sm">
+      <div class="mb-6 flex flex-col items-center gap-3 text-center">
+        <SigahLogo :size="56" />
+        <div>
+          <h1 class="text-2xl font-bold tracking-tight text-neutral-900">Cambiar contraseña</h1>
+          <p class="text-sm text-neutral-500">Define una contraseña personal y segura</p>
+        </div>
+      </div>
+
+      <p
+        v-if="auth.mustChangePassword"
+        class="mb-4 rounded-md border border-warning-br bg-warning-bg p-3 text-sm text-warning"
+      >
+        Tu contraseña es temporal. Debes cambiarla antes de continuar.
       </p>
+
+      <form
+        class="space-y-5 rounded-xl border border-neutral-200 bg-white p-6 shadow-sm"
+        @submit.prevent="onSubmit"
+      >
+        <FormField label="Contraseña actual" required :error="errors.current" input-id="cp-current">
+          <input
+            id="cp-current"
+            v-model="current"
+            type="password"
+            autocomplete="current-password"
+            class="control"
+          />
+        </FormField>
+
+        <FormField
+          label="Nueva contraseña"
+          required
+          :error="errors.next"
+          input-id="cp-next"
+          hint="Mínimo 8 caracteres."
+        >
+          <input id="cp-next" v-model="next" type="password" autocomplete="new-password" class="control" />
+        </FormField>
+
+        <FormField label="Confirmar nueva contraseña" required :error="errors.confirm" input-id="cp-confirm">
+          <input
+            id="cp-confirm"
+            v-model="confirm"
+            type="password"
+            autocomplete="new-password"
+            class="control"
+          />
+        </FormField>
+
+        <AppButton type="submit" :disabled="loading" class="w-full">
+          {{ loading ? 'Guardando…' : 'Cambiar contraseña' }}
+        </AppButton>
+      </form>
+
+      <button
+        type="button"
+        class="mt-4 w-full text-center text-sm text-neutral-500 hover:text-neutral-700"
+        @click="onLogout"
+      >
+        Cerrar sesión
+      </button>
     </div>
   </div>
 </template>

--- a/client/src/pages/auth/LoginPage.vue
+++ b/client/src/pages/auth/LoginPage.vue
@@ -20,7 +20,7 @@ async function onSubmit() {
   try {
     const user = await auth.login({ email: email.value, password: password.value })
     const redirect = (route.query.redirect as string) || '/dashboard'
-    router.push(user.password_must_change ? '/change-password' : redirect)
+    router.push(user?.password_must_change ? '/change-password' : redirect)
   } catch {
     // TODO: mostrar cuenta regresiva de lockout usando locked_until (HU-02 CA5).
     toast.error('Credenciales inválidas o cuenta bloqueada')

--- a/client/src/pages/users/UsersPage.vue
+++ b/client/src/pages/users/UsersPage.vue
@@ -1,0 +1,347 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { toast } from 'vue-sonner'
+import {
+  UserPlus, Power, KeyRound, SearchX, RotateCcw, ChevronLeft, ChevronRight,
+  Copy, Check, RefreshCw,
+} from '@lucide/vue'
+import { useUsersList, useUserMutations } from '@/composables/useUsers'
+import { useAuthStore } from '@/stores/auth'
+import { ROLE_LABELS } from '@/utils/constants'
+import { ROLE_OPTIONS } from '@/types/user.types'
+import type { RegisterUserPayload, UserListItem, UsersListParams } from '@/types/user.types'
+import type { Role } from '@/types/auth.types'
+import { registerUserSchema } from '@/schemas/user.schema'
+import { validate } from '@/utils/validation'
+import { apiErrorMessage } from '@/utils/apiError'
+import PageHeader from '@/components/ui/PageHeader.vue'
+import AppButton from '@/components/ui/AppButton.vue'
+import DataTable from '@/components/ui/DataTable.vue'
+import EmptyState from '@/components/ui/EmptyState.vue'
+import SkeletonBlock from '@/components/ui/SkeletonBlock.vue'
+import BaseModal from '@/components/ui/BaseModal.vue'
+import ConfirmDialog from '@/components/ui/ConfirmDialog.vue'
+import FormField from '@/components/form/FormField.vue'
+import SelectField from '@/components/form/SelectField.vue'
+
+const PAGE_SIZE = 20
+const auth = useAuthStore()
+
+// --- Filtros + listado --------------------------------------------------------
+const roleFilter = ref('')
+const activeFilter = ref('')
+const page = ref(1)
+
+watch([roleFilter, activeFilter], () => {
+  page.value = 1
+})
+
+const params = computed<UsersListParams>(() => ({
+  page: page.value,
+  per_page: PAGE_SIZE,
+  ...(roleFilter.value ? { role: roleFilter.value as Role } : {}),
+  ...(activeFilter.value ? { is_active: activeFilter.value === 'true' } : {}),
+}))
+
+const { data, isLoading, isFetching, isError, refetch } = useUsersList(params)
+const rows = computed(() => data.value?.data ?? [])
+const total = computed(() => data.value?.total ?? 0)
+const totalPages = computed(() => Math.max(1, Math.ceil(total.value / PAGE_SIZE)))
+const rangeFrom = computed(() => (total.value === 0 ? 0 : (page.value - 1) * PAGE_SIZE + 1))
+const rangeTo = computed(() => Math.min(page.value * PAGE_SIZE, total.value))
+const hasFilters = computed(() => !!(roleFilter.value || activeFilter.value))
+
+const roleFilterOptions = [{ value: '', label: 'Todos los roles' }, ...ROLE_OPTIONS]
+const activeFilterOptions = [
+  { value: '', label: 'Todos los estados' },
+  { value: 'true', label: 'Activos' },
+  { value: 'false', label: 'Inactivos' },
+]
+const roleFormOptions = [{ value: '', label: 'Selecciona el rol…' }, ...ROLE_OPTIONS]
+
+const columns = [
+  { key: 'name', label: 'Nombre' },
+  { key: 'email', label: 'Correo' },
+  { key: 'role', label: 'Rol' },
+  { key: 'is_active', label: 'Estado', align: 'center' as const },
+  { key: 'last_login_at', label: 'Último acceso' },
+  { key: 'actions', label: '', align: 'right' as const },
+]
+
+const asUser = (r: unknown) => r as UserListItem
+function goTo(p: number) {
+  page.value = Math.min(Math.max(1, p), totalPages.value)
+}
+function clearFilters() {
+  roleFilter.value = ''
+  activeFilter.value = ''
+}
+function fmtDateTime(s: string | null) {
+  if (!s) return 'Nunca'
+  return new Date(s).toLocaleString('es-CO', { dateStyle: 'medium', timeStyle: 'short' })
+}
+
+// --- Mutaciones ---------------------------------------------------------------
+const { register, setActive, resetPassword } = useUserMutations()
+
+// --- Modal registrar ----------------------------------------------------------
+const modalOpen = ref(false)
+const errors = ref<Record<string, string>>({})
+const saving = computed(() => register.isPending.value)
+function blankForm() {
+  return { name: '', email: '', role: '', password: '' }
+}
+const form = ref(blankForm())
+
+function openCreate() {
+  form.value = blankForm()
+  errors.value = {}
+  modalOpen.value = true
+}
+function generatePassword() {
+  form.value.password = crypto.randomUUID().replace(/-/g, '').slice(0, 12)
+}
+async function submit() {
+  const res = validate(registerUserSchema, { ...form.value })
+  if (!res.ok) {
+    errors.value = res.errors
+    return
+  }
+  errors.value = {}
+  try {
+    await register.mutateAsync(res.data as RegisterUserPayload)
+    toast.success(`Usuario ${res.data.email} creado. Deberá cambiar la contraseña al ingresar.`)
+    modalOpen.value = false
+  } catch (e) {
+    toast.error(apiErrorMessage(e, 'No se pudo crear el usuario. ¿El correo ya existe?'))
+  }
+}
+
+// --- Activar / desactivar -----------------------------------------------------
+async function toggleActive(u: UserListItem) {
+  if (u.id === auth.user?.id) {
+    toast.error('No puedes desactivar tu propia cuenta.')
+    return
+  }
+  try {
+    await setActive.mutateAsync({ id: u.id, isActive: !u.is_active })
+    toast.success(u.is_active ? 'Usuario desactivado' : 'Usuario activado')
+  } catch (e) {
+    toast.error(apiErrorMessage(e))
+  }
+}
+
+// --- Resetear contraseña ------------------------------------------------------
+const resetConfirmOpen = ref(false)
+const resetTarget = ref<UserListItem | null>(null)
+const resetResultOpen = ref(false)
+const resetPwd = ref('')
+const copied = ref(false)
+const resetting = computed(() => resetPassword.isPending.value)
+
+function askReset(u: UserListItem) {
+  resetTarget.value = u
+  resetConfirmOpen.value = true
+}
+async function confirmReset() {
+  if (!resetTarget.value) return
+  try {
+    const result = await resetPassword.mutateAsync(resetTarget.value.id)
+    resetPwd.value = result.temporary_password
+    copied.value = false
+    resetConfirmOpen.value = false
+    resetResultOpen.value = true
+  } catch (e) {
+    toast.error(apiErrorMessage(e))
+    resetConfirmOpen.value = false
+  }
+}
+async function copyPwd() {
+  try {
+    await navigator.clipboard.writeText(resetPwd.value)
+    copied.value = true
+    setTimeout(() => (copied.value = false), 2000)
+  } catch {
+    toast.error('No se pudo copiar al portapapeles')
+  }
+}
+</script>
+
+<template>
+  <section class="space-y-5">
+    <PageHeader
+      title="Usuarios"
+      crumb="Administración"
+      :subtitle="total ? `${total} ${total === 1 ? 'usuario' : 'usuarios'} del sistema` : 'Gestión de cuentas y roles'"
+    >
+      <template #actions>
+        <AppButton @click="openCreate"><UserPlus /> Registrar usuario</AppButton>
+      </template>
+    </PageHeader>
+
+    <!-- Filtros -->
+    <div class="grid grid-cols-1 gap-3 rounded-lg border border-neutral-200 bg-white p-4 sm:grid-cols-2">
+      <SelectField v-model="roleFilter" :options="roleFilterOptions" />
+      <SelectField v-model="activeFilter" :options="activeFilterOptions" />
+    </div>
+
+    <!-- Error -->
+    <div v-if="isError" class="rounded-lg border border-danger-br bg-danger-bg p-6 text-center">
+      <p class="text-sm text-danger">No se pudieron cargar los usuarios.</p>
+      <AppButton variant="outline" size="sm" class="mt-3" @click="() => refetch()">
+        <RotateCcw /> Reintentar
+      </AppButton>
+    </div>
+
+    <!-- Carga inicial -->
+    <div v-else-if="isLoading" class="space-y-2 rounded-lg border border-neutral-200 bg-white p-4">
+      <SkeletonBlock v-for="n in 8" :key="n" height="44px" />
+    </div>
+
+    <!-- Datos -->
+    <template v-else>
+      <div :class="{ 'opacity-60 transition-opacity': isFetching }">
+        <DataTable :columns="columns" :rows="rows" row-key="id" min-width="900px">
+          <template #name="{ row }">
+            <div>
+              <p class="font-semibold text-neutral-900">
+                {{ asUser(row).name }}
+                <span v-if="asUser(row).id === auth.user?.id" class="ml-1 text-xs font-normal text-neutral-400">(tú)</span>
+              </p>
+              <p v-if="asUser(row).password_must_change" class="text-xs text-warning">Contraseña temporal pendiente</p>
+            </div>
+          </template>
+
+          <template #email="{ row }"><span class="text-neutral-600">{{ asUser(row).email }}</span></template>
+
+          <template #role="{ row }">{{ ROLE_LABELS[asUser(row).role] }}</template>
+
+          <template #is_active="{ row }">
+            <span
+              :class="[
+                'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-semibold',
+                asUser(row).is_active
+                  ? 'border-success-br bg-success-bg text-success'
+                  : 'border-neutral-200 bg-neutral-100 text-neutral-500',
+              ]"
+            >
+              <span class="h-[7px] w-[7px] rounded-full bg-current" />
+              {{ asUser(row).is_active ? 'Activo' : 'Inactivo' }}
+            </span>
+          </template>
+
+          <template #last_login_at="{ row }">
+            <span class="text-sm text-neutral-600">{{ fmtDateTime(asUser(row).last_login_at) }}</span>
+          </template>
+
+          <template #actions="{ row }">
+            <div class="flex justify-end gap-1">
+              <AppButton variant="ghost" size="sm" @click="askReset(asUser(row))">
+                <KeyRound /> Resetear
+              </AppButton>
+              <AppButton
+                variant="ghost"
+                size="sm"
+                :class="asUser(row).is_active ? 'text-danger' : 'text-success'"
+                :disabled="asUser(row).id === auth.user?.id"
+                @click="toggleActive(asUser(row))"
+              >
+                <Power /> {{ asUser(row).is_active ? 'Desactivar' : 'Activar' }}
+              </AppButton>
+            </div>
+          </template>
+
+          <template #empty>
+            <EmptyState
+              title="Sin usuarios"
+              :message="hasFilters ? 'No hay usuarios que coincidan con los filtros.' : 'Aún no hay usuarios registrados.'"
+            >
+              <template #icon><SearchX /></template>
+              <template #action>
+                <AppButton v-if="hasFilters" variant="outline" size="sm" @click="clearFilters">
+                  <RotateCcw /> Limpiar filtros
+                </AppButton>
+                <AppButton v-else size="sm" @click="openCreate"><UserPlus /> Registrar usuario</AppButton>
+              </template>
+            </EmptyState>
+          </template>
+        </DataTable>
+      </div>
+
+      <!-- Paginación -->
+      <div v-if="total > 0" class="flex flex-wrap items-center justify-between gap-3 text-sm text-neutral-600">
+        <span>Mostrando <strong>{{ rangeFrom }}–{{ rangeTo }}</strong> de <strong>{{ total }}</strong></span>
+        <div class="flex items-center gap-2">
+          <AppButton variant="outline" size="sm" :disabled="page <= 1" @click="goTo(page - 1)"><ChevronLeft /></AppButton>
+          <span class="px-1">Página {{ page }} de {{ totalPages }}</span>
+          <AppButton variant="outline" size="sm" :disabled="page >= totalPages" @click="goTo(page + 1)"><ChevronRight /></AppButton>
+        </div>
+      </div>
+    </template>
+
+    <!-- Modal registrar -->
+    <BaseModal :open="modalOpen" title="Registrar usuario" max-width="max-w-[560px]" @close="modalOpen = false">
+      <form class="space-y-4" @submit.prevent="submit">
+        <FormField label="Nombre completo" required :error="errors.name" input-id="us-name">
+          <input id="us-name" v-model="form.name" class="control" placeholder="Nombre y apellidos" />
+        </FormField>
+        <FormField label="Correo" required :error="errors.email" input-id="us-email">
+          <input id="us-email" v-model="form.email" type="email" class="control" placeholder="usuario@monteria.gov.co" />
+        </FormField>
+        <SelectField
+          v-model="form.role"
+          label="Rol"
+          required
+          :options="roleFormOptions"
+          :error="errors.role"
+          input-id="us-role"
+        />
+        <FormField
+          label="Contraseña temporal"
+          required
+          :error="errors.password"
+          input-id="us-pwd"
+          hint="El usuario deberá cambiarla en su primer ingreso."
+        >
+          <div class="flex gap-2">
+            <input id="us-pwd" v-model="form.password" class="control" placeholder="Mínimo 8 caracteres" />
+            <AppButton type="button" variant="outline" @click="generatePassword"><RefreshCw /> Generar</AppButton>
+          </div>
+        </FormField>
+      </form>
+      <template #footer>
+        <AppButton variant="ghost" @click="modalOpen = false">Cancelar</AppButton>
+        <AppButton :disabled="saving" @click="submit">{{ saving ? 'Creando…' : 'Crear usuario' }}</AppButton>
+      </template>
+    </BaseModal>
+
+    <!-- Confirmar reseteo -->
+    <ConfirmDialog
+      :open="resetConfirmOpen"
+      tone="warning"
+      title="Resetear contraseña"
+      :message="resetTarget ? `Se generará una contraseña temporal para “${resetTarget.name}”. Deberá cambiarla al ingresar.` : ''"
+      :confirm-label="resetting ? 'Generando…' : 'Resetear'"
+      @confirm="confirmReset"
+      @close="resetConfirmOpen = false"
+    />
+
+    <!-- Resultado del reseteo: contraseña temporal (se muestra una sola vez) -->
+    <BaseModal :open="resetResultOpen" title="Contraseña temporal generada" max-width="max-w-[460px]" @close="resetResultOpen = false">
+      <div class="space-y-3">
+        <p class="text-sm text-neutral-600">
+          Comparte esta contraseña con el usuario por un canal seguro. <strong>No se volverá a mostrar.</strong>
+        </p>
+        <div class="flex items-center justify-between gap-3 rounded-md border border-neutral-300 bg-neutral-50 p-3">
+          <code class="font-mono text-base text-neutral-900">{{ resetPwd }}</code>
+          <AppButton variant="outline" size="sm" @click="copyPwd">
+            <Check v-if="copied" /> <Copy v-else /> {{ copied ? 'Copiado' : 'Copiar' }}
+          </AppButton>
+        </div>
+      </div>
+      <template #footer>
+        <AppButton @click="resetResultOpen = false">Entendido</AppButton>
+      </template>
+    </BaseModal>
+  </section>
+</template>

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -55,6 +55,13 @@ const router = createRouter({
           name: 'person-search',
           component: () => import('@/pages/persons/PersonSearchPage.vue'),
         },
+        // Gestión de usuarios (HU-01/03): solo ADMIN.
+        {
+          path: 'users',
+          name: 'users',
+          component: () => import('@/pages/users/UsersPage.vue'),
+          meta: { roles: ['ADMIN'] },
+        },
         // Zonas (HU-09) y Refugios (HU-10): CRUD restringido a ADMIN/COORDINADOR.
         {
           path: 'zones',

--- a/client/src/schemas/user.schema.ts
+++ b/client/src/schemas/user.schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod'
+
+// Formulario de registro de usuario (solo ADMIN, HU-01). Refleja POST /auth/register.
+export const registerUserSchema = z.object({
+  name: z.string().trim().min(2, 'Mínimo 2 caracteres').max(120, 'Máximo 120 caracteres'),
+  email: z.string().trim().toLowerCase().email('Correo inválido'),
+  password: z.string().min(8, 'La contraseña temporal debe tener al menos 8 caracteres'),
+  role: z.enum(
+    ['ADMIN', 'CENSADOR', 'OPERADOR_ENTREGAS', 'COORDINADOR_LOGISTICA', 'FUNCIONARIO_CONTROL', 'REGISTRADOR_DONACIONES'],
+    { message: 'Selecciona el rol' },
+  ),
+})
+
+export type RegisterUserValues = z.infer<typeof registerUserSchema>

--- a/client/src/stores/auth.ts
+++ b/client/src/stores/auth.ts
@@ -18,16 +18,26 @@ export const useAuthStore = defineStore('auth', () => {
     localStorage.setItem(TOKEN_KEY, newToken)
   }
 
+  // Login: el backend devuelve solo el token; el perfil (rol, password_must_change)
+  // se obtiene con /auth/me. Devuelve el usuario cargado (o null si falla /me).
   async function login(payload: LoginPayload) {
-    const res = await authApi.login(payload)
-    setSession(res.token, res.user)
-    return res.user
+    const { token: newToken } = await authApi.login(payload)
+    token.value = newToken
+    localStorage.setItem(TOKEN_KEY, newToken)
+    return await fetchMe()
   }
 
   async function fetchMe() {
     if (!token.value) return null
     user.value = await authApi.me()
     return user.value
+  }
+
+  // Cambio de contraseña propio (HU-03). Tras el cambio el backend pone
+  // password_must_change=false; recargamos el perfil para reflejarlo.
+  async function changePassword(oldPassword: string, newPassword: string) {
+    await authApi.changePassword({ oldPassword, newPassword })
+    await fetchMe()
   }
 
   function logout() {
@@ -48,6 +58,7 @@ export const useAuthStore = defineStore('auth', () => {
     setSession,
     login,
     fetchMe,
+    changePassword,
     logout,
     hasRole,
   }

--- a/client/src/types/auth.types.ts
+++ b/client/src/types/auth.types.ts
@@ -7,6 +7,7 @@ export type Role =
   | 'FUNCIONARIO_CONTROL'
   | 'REGISTRADOR_DONACIONES'
 
+// Perfil devuelto por GET /auth/me (briefUserView del backend).
 export interface User {
   id: number
   email: string
@@ -14,6 +15,8 @@ export interface User {
   role: Role
   is_active: boolean
   password_must_change: boolean
+  created_at?: string
+  updated_at?: string
   last_login_at?: string | null
 }
 
@@ -22,8 +25,8 @@ export interface LoginPayload {
   password: string
 }
 
-// NOTA: ajustar a la forma real de POST /auth/login cuando se integre.
+// POST /auth/login devuelve SOLO el token (sin user). El perfil se obtiene
+// luego con GET /auth/me. (Confirmado en server/src/services/auth.service.ts.)
 export interface LoginResponse {
   token: string
-  user: User
 }

--- a/client/src/types/user.types.ts
+++ b/client/src/types/user.types.ts
@@ -1,0 +1,62 @@
+import type { Role } from './auth.types'
+import { ROLE_LABELS } from '@/utils/constants'
+
+// Orden de roles para selects/etiquetas. Reusa ROLE_LABELS de utils/constants
+// (única fuente de verdad de los nombres en español).
+const ALL_ROLES: Role[] = [
+  'ADMIN',
+  'CENSADOR',
+  'OPERADOR_ENTREGAS',
+  'COORDINADOR_LOGISTICA',
+  'FUNCIONARIO_CONTROL',
+  'REGISTRADOR_DONACIONES',
+]
+
+export const ROLE_OPTIONS: { value: Role; label: string }[] = ALL_ROLES.map((r) => ({
+  value: r,
+  label: ROLE_LABELS[r],
+}))
+
+// Fila de GET /auth/users (fn_users_list: User sin password_hash).
+export interface UserListItem {
+  id: number
+  email: string
+  name: string
+  role: Role
+  is_active: boolean
+  password_must_change: boolean
+  last_login_at: string | null
+  created_at: string
+  updated_at: string
+}
+
+// GET /auth/users responde plano: { success, data, total, page, per_page }
+// (NO el envelope { data, pagination } del resto de módulos).
+export interface UsersListResponse {
+  success: boolean
+  data: UserListItem[]
+  total: number
+  page: number
+  per_page: number
+}
+
+export interface UsersListParams {
+  page: number
+  per_page: number
+  role?: Role
+  is_active?: boolean
+}
+
+// POST /auth/register (solo ADMIN). El backend marca password_must_change=true.
+export interface RegisterUserPayload {
+  email: string
+  password: string
+  name: string
+  role: Role
+}
+
+// POST /auth/reset-password/:userId → contraseña temporal generada (se muestra
+// una sola vez al ADMIN).
+export interface ResetPasswordResult {
+  temporary_password: string
+}


### PR DESCRIPTION
## Paso 3 del frontend (Vue): Auth completo

> **PR apilado** sobre #62 (familias). La base es `feature/fe-families-persons-hu04-08`; GitHub la re-apuntará a `dev` cuando #62 mergee. Revisar #62 primero.

### ⚠️ Fix de integración crítico
El login **no funcionaba** contra la API real: `auth.api.ts` no desenvolvía el envelope `{success,data}` del backend y el store leía `res.token`/`res.user` cuando `POST /auth/login` solo devuelve `{token}`. Sin esto, ninguna página autenticada cargaba (incluidas las de #62). Corregido:
- `auth.api.ts` desenvuelve a `.data.data` como el resto de la app; el perfil (rol, `password_must_change`) se obtiene con `GET /auth/me`.
- `stores/auth.ts`: `login` setea el token y luego carga `/me`; nueva acción `changePassword` que re-consulta `/me`.
- `change-password` usa `oldPassword`/`newPassword` (nombres reales del validador del backend).

### Pantallas
- **ChangePasswordPage** (HU-03): contraseña actual / nueva / confirmar (mín. 8); obligatoria cuando `password_must_change=true` (guard del router); re-fetch de `/me` y redirección; opción de cerrar sesión.
- **UsersPage** (HU-01, solo ADMIN): tabla (Nombre, Correo, Rol, Estado, Último acceso) con filtros rol/estado y paginación; **Registrar usuario** (modal con generador de contraseña temporal); **activar/desactivar** (bloquea desactivarse a sí mismo); **resetear contraseña** (muestra una sola vez la temporal generada por el backend, con botón copiar). Marca de "contraseña temporal pendiente" por fila.

### Soporte
- `types/user.types.ts`, `schemas/user.schema.ts`, `composables/useUsers.ts`; métodos `listUsers/register/setActive/resetPassword` en `auth.api.ts`.
- Ruta `/users` con `meta.roles: ['ADMIN']` (el sidebar ya enlazaba).

### Limitaciones (contrato del backend)
- **No hay edición de rol**: `PUT /auth/users/:id` solo togglea `is_active`. Se omite esa acción del UI.
- `GET /auth/users` usa paginación plana (`{data,total,page,per_page}`, param `per_page`), distinta del resto.

### Verificación
- ✅ `pnpm -C client typecheck`
- ✅ `pnpm -C client build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)