### PR TITLE
feat(client): Bodegas + Inventario (Paso 6) — HU-11/14/15/16/17

### DIFF
--- a/client/src/api/inventory.api.ts
+++ b/client/src/api/inventory.api.ts
@@ -1,0 +1,54 @@
+import { api } from './axios'
+import type { ApiItem, ApiList } from '@/types/api.types'
+import type {
+  AdjustInventoryPayload,
+  AlertThreshold,
+  InventoryAlert,
+  InventoryListParams,
+  InventoryRow,
+  InventorySummaryRow,
+  SetThresholdPayload,
+  UpsertInventoryPayload,
+} from '@/types/inventory.types'
+
+export const inventoryApi = {
+  list(params: InventoryListParams) {
+    const query: Record<string, string | number> = { page: params.page, limit: params.limit }
+    if (params.warehouse_id) query.warehouse_id = params.warehouse_id
+    if (params.resource_type_id) query.resource_type_id = params.resource_type_id
+    if (params.category) query.category = params.category
+    if (params.only_in_stock) query.only_in_stock = 'true'
+    return api.get<ApiList<InventoryRow>>('/inventory', { params: query }).then((r) => r.data)
+  },
+
+  summary(warehouseId?: number) {
+    return api
+      .get<ApiItem<InventorySummaryRow[]>>('/inventory/summary', {
+        params: warehouseId ? { warehouse_id: warehouseId } : {},
+      })
+      .then((r) => r.data.data)
+  },
+
+  alerts() {
+    return api.get<ApiItem<InventoryAlert[]>>('/inventory/alerts').then((r) => r.data.data)
+  },
+
+  // Upsert: si el lote existe suma la cantidad, si no lo crea.
+  upsert(payload: UpsertInventoryPayload) {
+    return api.post<ApiItem<InventoryRow>>('/inventory', payload).then((r) => r.data.data)
+  },
+
+  // Ajuste manual con motivo + nota (HU-17). El backend bloquea stock negativo (409).
+  adjust(id: number, payload: AdjustInventoryPayload) {
+    return api.put<ApiItem<InventoryRow>>(`/inventory/${id}/adjustment`, payload).then((r) => r.data.data)
+  },
+
+  listThresholds() {
+    return api.get<ApiItem<AlertThreshold[]>>('/alert-thresholds').then((r) => r.data.data)
+  },
+
+  // PUT /alert-thresholds = upsert (crea o actualiza por resource_type_id).
+  setThreshold(payload: SetThresholdPayload) {
+    return api.put<ApiItem<AlertThreshold>>('/alert-thresholds', payload).then((r) => r.data.data)
+  },
+}

--- a/client/src/api/resourceTypes.api.ts
+++ b/client/src/api/resourceTypes.api.ts
@@ -1,0 +1,27 @@
+import { api } from './axios'
+import type { ApiItem } from '@/types/api.types'
+import type { ResourceType, ResourceTypeListParams, ResourceTypePayload } from '@/types/inventory.types'
+
+export const resourceTypesApi = {
+  // GET /resource-types (sin paginación; devuelve el catálogo completo).
+  list(params: ResourceTypeListParams = {}) {
+    const query: Record<string, string> = {}
+    if (params.category) query.category = params.category
+    if (params.is_active !== undefined) query.is_active = String(params.is_active)
+    return api.get<ApiItem<ResourceType[]>>('/resource-types', { params: query }).then((r) => r.data.data)
+  },
+
+  create(payload: ResourceTypePayload) {
+    return api.post<ApiItem<ResourceType>>('/resource-types', payload).then((r) => r.data.data)
+  },
+
+  // PUT acepta también is_active (reactivar un recurso desactivado).
+  update(id: number, payload: Partial<ResourceTypePayload> & { is_active?: boolean }) {
+    return api.put<ApiItem<ResourceType>>(`/resource-types/${id}`, payload).then((r) => r.data.data)
+  },
+
+  // DELETE = soft delete (is_active=false) para preservar el histórico (HU-14 CA4).
+  deactivate(id: number) {
+    return api.delete(`/resource-types/${id}`).then(() => undefined)
+  },
+}

--- a/client/src/api/warehouses.api.ts
+++ b/client/src/api/warehouses.api.ts
@@ -1,0 +1,53 @@
+import { api } from './axios'
+import type { ApiItem, ApiList } from '@/types/api.types'
+import type {
+  Warehouse,
+  WarehouseListParams,
+  WarehousePayload,
+  WarehouseWithDistance,
+  WarehouseWithOccupancy,
+} from '@/types/warehouse.types'
+import type { InventoryRow } from '@/types/inventory.types'
+
+export const warehousesApi = {
+  // Catálogo completo para selects/joins (p. ej. resumen, ajustes).
+  listAll() {
+    return api
+      .get<ApiList<WarehouseWithOccupancy>>('/warehouses', { params: { page: 1, limit: 200 } })
+      .then((r) => r.data.data)
+  },
+
+  list(params: WarehouseListParams) {
+    const query: Record<string, string | number> = { page: params.page, limit: params.limit }
+    if (params.zone_id) query.zone_id = params.zone_id
+    if (params.status) query.status = params.status
+    if (params.search) query.search = params.search
+    return api.get<ApiList<WarehouseWithOccupancy>>('/warehouses', { params: query }).then((r) => r.data)
+  },
+
+  getById(id: number) {
+    return api.get<ApiItem<WarehouseWithOccupancy>>(`/warehouses/${id}`).then((r) => r.data.data)
+  },
+
+  inventory(id: number) {
+    return api.get<ApiItem<InventoryRow[]>>(`/warehouses/${id}/inventory`).then((r) => r.data.data)
+  },
+
+  nearest(lat: number, lng: number, limit = 5) {
+    return api
+      .get<ApiItem<WarehouseWithDistance[]>>('/warehouses/nearest', { params: { lat, lng, limit } })
+      .then((r) => r.data.data)
+  },
+
+  create(payload: WarehousePayload) {
+    return api.post<ApiItem<Warehouse>>('/warehouses', payload).then((r) => r.data.data)
+  },
+
+  update(id: number, payload: Partial<WarehousePayload>) {
+    return api.put<ApiItem<Warehouse>>(`/warehouses/${id}`, payload).then((r) => r.data.data)
+  },
+
+  remove(id: number) {
+    return api.delete(`/warehouses/${id}`).then(() => undefined)
+  },
+}

--- a/client/src/components/layout/AppSidebar.vue
+++ b/client/src/components/layout/AppSidebar.vue
@@ -12,10 +12,13 @@ import {
   Home,
   Warehouse,
   Package,
+  Boxes,
+  Bell,
   Truck,
   Activity,
   BarChart3,
   Settings,
+  SlidersHorizontal,
   ShieldCheck,
 } from '@lucide/vue'
 
@@ -59,6 +62,8 @@ const groups: NavGroup[] = [
     items: [
       { label: 'Bodegas', to: '/warehouses', icon: Warehouse, roles: ['ADMIN', 'COORDINADOR_LOGISTICA'] },
       { label: 'Inventario', to: '/inventory/summary', icon: Package },
+      { label: 'Tipos de Recurso', to: '/inventory/resource-types', icon: Boxes, roles: ['ADMIN', 'COORDINADOR_LOGISTICA'] },
+      { label: 'Alertas', to: '/inventory/alerts', icon: Bell },
     ],
   },
   {
@@ -82,6 +87,7 @@ const groups: NavGroup[] = [
     title: 'Configuración',
     items: [
       { label: 'Puntaje', to: '/settings/scoring', icon: Settings, roles: ['ADMIN', 'COORDINADOR_LOGISTICA'] },
+      { label: 'Umbrales', to: '/settings/alerts', icon: SlidersHorizontal, roles: ['ADMIN', 'COORDINADOR_LOGISTICA'] },
     ],
   },
   {

--- a/client/src/composables/useInventory.ts
+++ b/client/src/composables/useInventory.ts
@@ -1,0 +1,61 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query'
+import type { Ref } from 'vue'
+import { inventoryApi } from '@/api/inventory.api'
+import type { AdjustInventoryPayload, SetThresholdPayload, UpsertInventoryPayload } from '@/types/inventory.types'
+
+// Resumen por bodega/categoría. warehouseId opcional (global si no se pasa).
+export function useInventorySummary(warehouseId?: Ref<number | undefined>) {
+  return useQuery({
+    queryKey: ['inventory', 'summary', warehouseId ?? { global: true }],
+    queryFn: () => inventoryApi.summary(warehouseId?.value),
+  })
+}
+
+export function useInventoryAlerts() {
+  return useQuery({
+    queryKey: ['inventory', 'alerts'],
+    queryFn: inventoryApi.alerts,
+    staleTime: 1000 * 60,
+  })
+}
+
+// Upsert (agregar stock) y ajuste manual. Afectan el peso de la bodega → invalida
+// bodegas también.
+export function useInventoryMutations() {
+  const qc = useQueryClient()
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: ['inventory'] })
+    qc.invalidateQueries({ queryKey: ['warehouses'] })
+  }
+
+  const upsert = useMutation({
+    mutationFn: (payload: UpsertInventoryPayload) => inventoryApi.upsert(payload),
+    onSuccess: invalidate,
+  })
+  const adjust = useMutation({
+    mutationFn: ({ id, payload }: { id: number; payload: AdjustInventoryPayload }) =>
+      inventoryApi.adjust(id, payload),
+    onSuccess: invalidate,
+  })
+
+  return { upsert, adjust }
+}
+
+export function useAlertThresholds() {
+  return useQuery({
+    queryKey: ['alert-thresholds'],
+    queryFn: inventoryApi.listThresholds,
+  })
+}
+
+export function useThresholdMutations() {
+  const qc = useQueryClient()
+  const setThreshold = useMutation({
+    mutationFn: (payload: SetThresholdPayload) => inventoryApi.setThreshold(payload),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['alert-thresholds'] })
+      qc.invalidateQueries({ queryKey: ['inventory'] })
+    },
+  })
+  return { setThreshold }
+}

--- a/client/src/composables/useResourceTypes.ts
+++ b/client/src/composables/useResourceTypes.ts
@@ -1,0 +1,38 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query'
+import type { Ref } from 'vue'
+import { resourceTypesApi } from '@/api/resourceTypes.api'
+import type { ResourceTypeListParams, ResourceTypePayload } from '@/types/inventory.types'
+
+// Catálogo de tipos de recurso. Acepta filtros reactivos (categoría / activos).
+export function useResourceTypes(params?: Ref<ResourceTypeListParams>) {
+  return useQuery({
+    queryKey: ['resource-types', params ?? { all: true }],
+    queryFn: () => resourceTypesApi.list(params?.value),
+  })
+}
+
+// Mutaciones del catálogo. Invalida recursos y también inventario/umbrales/alertas
+// (dependen del catálogo).
+export function useResourceTypeMutations() {
+  const qc = useQueryClient()
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: ['resource-types'] })
+    qc.invalidateQueries({ queryKey: ['inventory'] })
+    qc.invalidateQueries({ queryKey: ['alert-thresholds'] })
+  }
+
+  const create = useMutation({ mutationFn: resourceTypesApi.create, onSuccess: invalidate })
+  const update = useMutation({
+    mutationFn: ({
+      id,
+      payload,
+    }: {
+      id: number
+      payload: Partial<ResourceTypePayload> & { is_active?: boolean }
+    }) => resourceTypesApi.update(id, payload),
+    onSuccess: invalidate,
+  })
+  const deactivate = useMutation({ mutationFn: resourceTypesApi.deactivate, onSuccess: invalidate })
+
+  return { create, update, deactivate }
+}

--- a/client/src/composables/useWarehouses.ts
+++ b/client/src/composables/useWarehouses.ts
@@ -1,0 +1,56 @@
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/vue-query'
+import { computed, type Ref } from 'vue'
+import { warehousesApi } from '@/api/warehouses.api'
+import type { WarehouseListParams, WarehousePayload } from '@/types/warehouse.types'
+
+// Catálogo completo de bodegas (selects/joins).
+export function useWarehouses() {
+  return useQuery({
+    queryKey: ['warehouses', 'all'],
+    queryFn: warehousesApi.listAll,
+    staleTime: 1000 * 60 * 5,
+  })
+}
+
+export function useWarehousesList(params: Ref<WarehouseListParams>) {
+  return useQuery({
+    queryKey: ['warehouses', 'list', params],
+    queryFn: () => warehousesApi.list(params.value),
+    placeholderData: keepPreviousData,
+  })
+}
+
+export function useWarehouse(id: Ref<number>) {
+  return useQuery({
+    queryKey: ['warehouses', 'detail', id],
+    queryFn: () => warehousesApi.getById(id.value),
+    enabled: computed(() => id.value > 0),
+  })
+}
+
+export function useWarehouseInventory(id: Ref<number>) {
+  return useQuery({
+    queryKey: ['warehouses', 'inventory', id],
+    queryFn: () => warehousesApi.inventory(id.value),
+    enabled: computed(() => id.value > 0),
+  })
+}
+
+// Mutaciones de bodega. Invalida bodegas y zonas (el detalle de zona cuenta sus bodegas).
+export function useWarehouseMutations() {
+  const qc = useQueryClient()
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: ['warehouses'] })
+    qc.invalidateQueries({ queryKey: ['zones'] })
+  }
+
+  const create = useMutation({ mutationFn: warehousesApi.create, onSuccess: invalidate })
+  const update = useMutation({
+    mutationFn: ({ id, payload }: { id: number; payload: Partial<WarehousePayload> }) =>
+      warehousesApi.update(id, payload),
+    onSuccess: invalidate,
+  })
+  const remove = useMutation({ mutationFn: warehousesApi.remove, onSuccess: invalidate })
+
+  return { create, update, remove }
+}

--- a/client/src/pages/inventory/InventoryAlertsPage.vue
+++ b/client/src/pages/inventory/InventoryAlertsPage.vue
@@ -1,0 +1,116 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRouter } from 'vue-router'
+import {
+  ShieldCheck, RotateCcw, PackageX, CalendarClock, CalendarX, TriangleAlert, ChevronRight,
+} from '@lucide/vue'
+import type { Component } from 'vue'
+import { useInventoryAlerts } from '@/composables/useInventory'
+import { ALERT_KIND_LABELS, ALERT_SEVERITY_LABELS } from '@/types/inventory.types'
+import type { AlertKind, AlertSeverity, InventoryAlert } from '@/types/inventory.types'
+import PageHeader from '@/components/ui/PageHeader.vue'
+import AppButton from '@/components/ui/AppButton.vue'
+import EmptyState from '@/components/ui/EmptyState.vue'
+import SkeletonBlock from '@/components/ui/SkeletonBlock.vue'
+
+const router = useRouter()
+const { data, isLoading, isError, refetch } = useInventoryAlerts()
+
+const SEVERITY_RANK: Record<AlertSeverity, number> = { CRITICAL: 0, HIGH: 1, MEDIUM: 2 }
+const SEVERITY_CLASSES: Record<AlertSeverity, string> = {
+  CRITICAL: 'border-l-danger bg-danger-bg',
+  HIGH: 'border-l-risk-high bg-risk-high-bg',
+  MEDIUM: 'border-l-warning bg-warning-bg',
+}
+const SEVERITY_BADGE: Record<AlertSeverity, string> = {
+  CRITICAL: 'bg-danger text-white',
+  HIGH: 'bg-risk-high text-white',
+  MEDIUM: 'bg-warning text-white',
+}
+const KIND_ICON: Record<AlertKind, Component> = {
+  LOW_STOCK: PackageX,
+  EXPIRING_SOON: CalendarClock,
+  EXPIRED: CalendarX,
+  WAREHOUSE_OVER_85: TriangleAlert,
+}
+
+const alerts = computed(() =>
+  [...(data.value ?? [])].sort((a, b) => SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity]),
+)
+const counts = computed(() => {
+  const c = { CRITICAL: 0, HIGH: 0, MEDIUM: 0 } as Record<AlertSeverity, number>
+  for (const a of alerts.value) c[a.severity]++
+  return c
+})
+
+function goTo(alert: InventoryAlert) {
+  if (alert.link && alert.link.startsWith('/')) router.push(alert.link)
+}
+</script>
+
+<template>
+  <section class="space-y-5">
+    <PageHeader
+      title="Alertas de inventario"
+      crumb="Logística"
+      :subtitle="alerts.length ? `${alerts.length} alerta(s) activa(s)` : 'Stock bajo, vencimientos y capacidad'"
+    >
+      <template #actions>
+        <AppButton variant="outline" size="sm" @click="() => refetch()"><RotateCcw /> Actualizar</AppButton>
+      </template>
+    </PageHeader>
+
+    <div v-if="isError" class="rounded-lg border border-danger-br bg-danger-bg p-6 text-center">
+      <p class="text-sm text-danger">No se pudieron cargar las alertas.</p>
+      <AppButton variant="outline" size="sm" class="mt-3" @click="() => refetch()"><RotateCcw /> Reintentar</AppButton>
+    </div>
+
+    <div v-else-if="isLoading" class="space-y-3">
+      <SkeletonBlock v-for="n in 4" :key="n" height="72px" />
+    </div>
+
+    <div v-else-if="!alerts.length" class="rounded-lg border border-success-br bg-success-bg">
+      <EmptyState title="Todo en orden" message="No hay alertas de inventario activas en este momento.">
+        <template #icon><ShieldCheck /></template>
+      </EmptyState>
+    </div>
+
+    <template v-else>
+      <!-- Resumen por severidad -->
+      <div class="flex flex-wrap gap-2 text-sm">
+        <span v-if="counts.CRITICAL" class="rounded-full bg-danger px-3 py-1 font-semibold text-white">{{ counts.CRITICAL }} críticas</span>
+        <span v-if="counts.HIGH" class="rounded-full bg-risk-high px-3 py-1 font-semibold text-white">{{ counts.HIGH }} altas</span>
+        <span v-if="counts.MEDIUM" class="rounded-full bg-warning px-3 py-1 font-semibold text-white">{{ counts.MEDIUM }} medias</span>
+      </div>
+
+      <ul class="space-y-3">
+        <li
+          v-for="(a, i) in alerts"
+          :key="i"
+          :class="['flex items-center gap-4 rounded-lg border border-neutral-200 border-l-4 bg-white p-4', SEVERITY_CLASSES[a.severity]]"
+        >
+          <span class="grid h-10 w-10 flex-none place-items-center rounded-full bg-white/70 text-neutral-700 [&>svg]:h-5 [&>svg]:w-5">
+            <component :is="KIND_ICON[a.kind]" />
+          </span>
+          <div class="min-w-0 flex-1">
+            <div class="flex flex-wrap items-center gap-2">
+              <span :class="['rounded-full px-2 py-0.5 text-xs font-semibold', SEVERITY_BADGE[a.severity]]">
+                {{ ALERT_SEVERITY_LABELS[a.severity] }}
+              </span>
+              <span class="text-xs font-medium text-neutral-500">{{ ALERT_KIND_LABELS[a.kind] }}</span>
+            </div>
+            <p class="mt-1 text-sm text-neutral-800">{{ a.message }}</p>
+          </div>
+          <AppButton
+            v-if="a.link && a.link.startsWith('/')"
+            variant="ghost"
+            size="sm"
+            @click="goTo(a)"
+          >
+            Ver <ChevronRight />
+          </AppButton>
+        </li>
+      </ul>
+    </template>
+  </section>
+</template>

--- a/client/src/pages/inventory/InventorySummaryPage.vue
+++ b/client/src/pages/inventory/InventorySummaryPage.vue
@@ -1,0 +1,126 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { Boxes, Package, Warehouse as WarehouseIcon, Scale, RotateCcw } from '@lucide/vue'
+import { useInventorySummary } from '@/composables/useInventory'
+import { useWarehouses } from '@/composables/useWarehouses'
+import { RESOURCE_CATEGORY_LABELS } from '@/types/inventory.types'
+import type { ResourceCategory } from '@/types/inventory.types'
+import PageHeader from '@/components/ui/PageHeader.vue'
+import AppButton from '@/components/ui/AppButton.vue'
+import KpiCard from '@/components/ui/KpiCard.vue'
+import EmptyState from '@/components/ui/EmptyState.vue'
+import SkeletonBlock from '@/components/ui/SkeletonBlock.vue'
+import SelectField from '@/components/form/SelectField.vue'
+
+const warehouseFilter = ref('')
+const warehouseId = computed(() => (warehouseFilter.value ? Number(warehouseFilter.value) : undefined))
+
+const { data, isLoading, isError, refetch } = useInventorySummary(warehouseId)
+const { data: warehouses } = useWarehouses()
+
+const warehouseOptions = computed(() => [
+  { value: '', label: 'Todas las bodegas' },
+  ...(warehouses.value ?? []).map((w) => ({ value: String(w.id), label: w.name })),
+])
+
+// Solo filas-hoja (categoría no nula) para evitar doble conteo si el backend
+// incluyera subtotales con category=null.
+const leaves = computed(() => (data.value ?? []).filter((r) => r.category != null))
+
+const totalWeight = computed(() => leaves.value.reduce((a, r) => a + r.total_weight_kg, 0))
+const totalItems = computed(() => leaves.value.reduce((a, r) => a + Number(r.total_quantity), 0))
+
+const byCategory = computed(() => {
+  const m = new Map<ResourceCategory, { weight: number; qty: number }>()
+  for (const r of leaves.value) {
+    const cat = r.category as ResourceCategory
+    const cur = m.get(cat) ?? { weight: 0, qty: 0 }
+    cur.weight += r.total_weight_kg
+    cur.qty += Number(r.total_quantity)
+    m.set(cat, cur)
+  }
+  return [...m.entries()]
+    .map(([category, v]) => ({ category, ...v }))
+    .sort((a, b) => b.weight - a.weight)
+})
+const maxCatWeight = computed(() => Math.max(1, ...byCategory.value.map((c) => c.weight)))
+
+const byWarehouse = computed(() => {
+  const m = new Map<number, { name: string; weight: number; qty: number }>()
+  for (const r of leaves.value) {
+    const cur = m.get(r.warehouse_id) ?? { name: r.warehouse_name, weight: 0, qty: 0 }
+    cur.weight += r.total_weight_kg
+    cur.qty += Number(r.total_quantity)
+    m.set(r.warehouse_id, cur)
+  }
+  return [...m.values()].sort((a, b) => b.weight - a.weight)
+})
+
+const kg = (n: number) => `${Math.round(n).toLocaleString('es-CO')} kg`
+const num = (n: number) => n.toLocaleString('es-CO')
+const isEmpty = computed(() => !isLoading.value && leaves.value.length === 0)
+</script>
+
+<template>
+  <section class="space-y-5">
+    <PageHeader title="Resumen de inventario" crumb="Logística" subtitle="Existencias agregadas por categoría y bodega">
+      <template #actions>
+        <div class="w-56"><SelectField v-model="warehouseFilter" :options="warehouseOptions" /></div>
+      </template>
+    </PageHeader>
+
+    <div v-if="isError" class="rounded-lg border border-danger-br bg-danger-bg p-6 text-center">
+      <p class="text-sm text-danger">No se pudo cargar el resumen.</p>
+      <AppButton variant="outline" size="sm" class="mt-3" @click="() => refetch()"><RotateCcw /> Reintentar</AppButton>
+    </div>
+
+    <div v-else-if="isLoading" class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <SkeletonBlock v-for="n in 4" :key="n" height="120px" />
+    </div>
+
+    <div v-else-if="isEmpty" class="rounded-lg border border-neutral-200 bg-white">
+      <EmptyState title="Sin existencias" message="No hay inventario registrado para mostrar.">
+        <template #icon><Boxes /></template>
+      </EmptyState>
+    </div>
+
+    <template v-else>
+      <!-- KPIs -->
+      <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <KpiCard label="Peso almacenado" :value="kg(totalWeight)"><template #icon><Scale /></template></KpiCard>
+        <KpiCard label="Unidades en stock" :value="num(totalItems)" tone="accent"><template #icon><Package /></template></KpiCard>
+        <KpiCard label="Categorías con stock" :value="byCategory.length"><template #icon><Boxes /></template></KpiCard>
+        <KpiCard label="Bodegas con stock" :value="byWarehouse.length" tone="accent"><template #icon><WarehouseIcon /></template></KpiCard>
+      </div>
+
+      <div class="grid grid-cols-1 gap-5 lg:grid-cols-2">
+        <!-- Por categoría -->
+        <div class="rounded-lg border border-neutral-200 bg-white p-5">
+          <h2 class="mb-4 text-sm font-semibold text-neutral-700">Peso por categoría</h2>
+          <div class="space-y-4">
+            <div v-for="c in byCategory" :key="c.category">
+              <div class="mb-1.5 flex justify-between text-sm">
+                <span class="font-medium text-neutral-700">{{ RESOURCE_CATEGORY_LABELS[c.category] }}</span>
+                <span class="font-mono text-neutral-900">{{ kg(c.weight) }} · {{ num(c.qty) }} u.</span>
+              </div>
+              <div class="h-2.5 overflow-hidden rounded-full bg-neutral-200">
+                <div class="h-full rounded-full bg-primary-600" :style="{ width: (c.weight / maxCatWeight) * 100 + '%' }" />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Por bodega -->
+        <div class="rounded-lg border border-neutral-200 bg-white p-5">
+          <h2 class="mb-4 text-sm font-semibold text-neutral-700">Peso por bodega</h2>
+          <ul class="divide-y divide-neutral-100">
+            <li v-for="w in byWarehouse" :key="w.name" class="flex items-center justify-between py-2.5">
+              <span class="text-sm text-neutral-700">{{ w.name }}</span>
+              <span class="font-mono text-sm text-neutral-900">{{ kg(w.weight) }} · {{ num(w.qty) }} u.</span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </template>
+  </section>
+</template>

--- a/client/src/pages/inventory/ResourceTypesPage.vue
+++ b/client/src/pages/inventory/ResourceTypesPage.vue
@@ -1,0 +1,253 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { toast } from 'vue-sonner'
+import { Plus, Pencil, Ban, RotateCw, SearchX, RotateCcw } from '@lucide/vue'
+import { useResourceTypes, useResourceTypeMutations } from '@/composables/useResourceTypes'
+import {
+  RESOURCE_CATEGORY_OPTIONS, RESOURCE_CATEGORY_LABELS,
+} from '@/types/inventory.types'
+import type {
+  ResourceCategory, ResourceType, ResourceTypeListParams, ResourceTypePayload,
+} from '@/types/inventory.types'
+import { resourceTypeSchema } from '@/schemas/resourceType.schema'
+import { validate } from '@/utils/validation'
+import { apiErrorMessage } from '@/utils/apiError'
+import PageHeader from '@/components/ui/PageHeader.vue'
+import AppButton from '@/components/ui/AppButton.vue'
+import DataTable from '@/components/ui/DataTable.vue'
+import EmptyState from '@/components/ui/EmptyState.vue'
+import SkeletonBlock from '@/components/ui/SkeletonBlock.vue'
+import BaseModal from '@/components/ui/BaseModal.vue'
+import ConfirmDialog from '@/components/ui/ConfirmDialog.vue'
+import SelectField from '@/components/form/SelectField.vue'
+import FormField from '@/components/form/FormField.vue'
+import RoleGate from '@/components/auth/RoleGate.vue'
+
+const EDIT_ROLES = ['ADMIN', 'COORDINADOR_LOGISTICA'] as const
+
+const categoryFilter = ref('')
+const statusFilter = ref('')
+const params = computed<ResourceTypeListParams>(() => ({
+  ...(categoryFilter.value ? { category: categoryFilter.value as ResourceCategory } : {}),
+  ...(statusFilter.value ? { is_active: statusFilter.value === 'true' } : {}),
+}))
+const { data, isLoading, isError, refetch, isFetching } = useResourceTypes(params)
+const rows = computed(() => data.value ?? [])
+const hasFilters = computed(() => !!(categoryFilter.value || statusFilter.value))
+
+const categoryFilterOptions = [{ value: '', label: 'Todas las categorías' }, ...RESOURCE_CATEGORY_OPTIONS]
+const categoryFormOptions = [{ value: '', label: 'Selecciona la categoría…' }, ...RESOURCE_CATEGORY_OPTIONS]
+const statusFilterOptions = [
+  { value: '', label: 'Todos' },
+  { value: 'true', label: 'Activos' },
+  { value: 'false', label: 'Inactivos' },
+]
+
+const columns = [
+  { key: 'name', label: 'Recurso' },
+  { key: 'category', label: 'Categoría' },
+  { key: 'unit', label: 'Unidad' },
+  { key: 'weight', label: 'Peso unitario', align: 'right' as const },
+  { key: 'status', label: 'Estado', align: 'center' as const },
+  { key: 'actions', label: '', align: 'right' as const },
+]
+const asRt = (r: unknown) => r as ResourceType
+
+function clearFilters() {
+  categoryFilter.value = ''
+  statusFilter.value = ''
+}
+
+// --- Modal crear / editar -----------------------------------------------------
+const { create, update, deactivate } = useResourceTypeMutations()
+const saving = computed(() => create.isPending.value || update.isPending.value)
+const modalOpen = ref(false)
+const editId = ref<number | null>(null)
+const errors = ref<Record<string, string>>({})
+function blankForm() {
+  return { name: '', category: '', unit_of_measure: '', unit_weight_kg: '' }
+}
+const form = ref(blankForm())
+
+function openCreate() {
+  editId.value = null
+  form.value = blankForm()
+  errors.value = {}
+  modalOpen.value = true
+}
+function openEdit(rt: ResourceType) {
+  editId.value = rt.id
+  form.value = {
+    name: rt.name,
+    category: rt.category,
+    unit_of_measure: rt.unit_of_measure,
+    unit_weight_kg: String(rt.unit_weight_kg),
+  }
+  errors.value = {}
+  modalOpen.value = true
+}
+async function submit() {
+  const res = validate(resourceTypeSchema, { ...form.value })
+  if (!res.ok) {
+    errors.value = res.errors
+    return
+  }
+  errors.value = {}
+  const payload: ResourceTypePayload = res.data
+  try {
+    if (editId.value != null) await update.mutateAsync({ id: editId.value, payload })
+    else await create.mutateAsync(payload)
+    toast.success(editId.value != null ? 'Recurso actualizado' : 'Recurso creado')
+    modalOpen.value = false
+  } catch (e) {
+    toast.error(apiErrorMessage(e, 'No se pudo guardar. ¿El nombre ya existe?'))
+  }
+}
+
+async function reactivate(rt: ResourceType) {
+  try {
+    await update.mutateAsync({ id: rt.id, payload: { is_active: true } })
+    toast.success('Recurso reactivado')
+  } catch (e) {
+    toast.error(apiErrorMessage(e))
+  }
+}
+
+// --- Desactivar (soft delete, HU-14 CA4) --------------------------------------
+const confirmOpen = ref(false)
+const target = ref<ResourceType | null>(null)
+function askDeactivate(rt: ResourceType) {
+  target.value = rt
+  confirmOpen.value = true
+}
+async function confirmDeactivate() {
+  if (!target.value) return
+  try {
+    await deactivate.mutateAsync(target.value.id)
+    toast.success('Recurso desactivado')
+  } catch (e) {
+    toast.error(apiErrorMessage(e))
+  } finally {
+    confirmOpen.value = false
+    target.value = null
+  }
+}
+</script>
+
+<template>
+  <section class="space-y-5">
+    <PageHeader title="Tipos de recurso" crumb="Logística" subtitle="Catálogo de insumos de ayuda humanitaria">
+      <template #actions>
+        <RoleGate :roles="[...EDIT_ROLES]">
+          <AppButton @click="openCreate"><Plus /> Nuevo recurso</AppButton>
+        </RoleGate>
+      </template>
+    </PageHeader>
+
+    <div class="grid grid-cols-1 gap-3 rounded-lg border border-neutral-200 bg-white p-4 sm:grid-cols-2">
+      <SelectField v-model="categoryFilter" :options="categoryFilterOptions" />
+      <SelectField v-model="statusFilter" :options="statusFilterOptions" />
+    </div>
+
+    <div v-if="isError" class="rounded-lg border border-danger-br bg-danger-bg p-6 text-center">
+      <p class="text-sm text-danger">No se pudieron cargar los recursos.</p>
+      <AppButton variant="outline" size="sm" class="mt-3" @click="() => refetch()"><RotateCcw /> Reintentar</AppButton>
+    </div>
+
+    <div v-else-if="isLoading" class="space-y-2 rounded-lg border border-neutral-200 bg-white p-4">
+      <SkeletonBlock v-for="n in 6" :key="n" height="44px" />
+    </div>
+
+    <div v-else :class="{ 'opacity-60 transition-opacity': isFetching }">
+      <DataTable :columns="columns" :rows="rows" row-key="id" min-width="760px">
+        <template #name="{ row }"><span class="font-medium text-neutral-900">{{ asRt(row).name }}</span></template>
+        <template #category="{ row }">{{ RESOURCE_CATEGORY_LABELS[asRt(row).category] }}</template>
+        <template #unit="{ row }"><span class="text-neutral-600">{{ asRt(row).unit_of_measure }}</span></template>
+        <template #weight="{ row }"><span class="font-mono text-xs">{{ asRt(row).unit_weight_kg }} kg</span></template>
+        <template #status="{ row }">
+          <span
+            :class="[
+              'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-semibold',
+              asRt(row).is_active
+                ? 'border-success-br bg-success-bg text-success'
+                : 'border-neutral-200 bg-neutral-100 text-neutral-500',
+            ]"
+          >
+            {{ asRt(row).is_active ? 'Activo' : 'Inactivo' }}
+          </span>
+        </template>
+        <template #actions="{ row }">
+          <RoleGate :roles="[...EDIT_ROLES]">
+            <div class="flex justify-end gap-1">
+              <AppButton variant="ghost" size="sm" @click="openEdit(asRt(row))"><Pencil /></AppButton>
+              <AppButton
+                v-if="asRt(row).is_active"
+                variant="ghost"
+                size="sm"
+                class="text-danger"
+                @click="askDeactivate(asRt(row))"
+              >
+                <Ban /> Desactivar
+              </AppButton>
+              <AppButton v-else variant="ghost" size="sm" class="text-success" @click="reactivate(asRt(row))">
+                <RotateCw /> Reactivar
+              </AppButton>
+            </div>
+          </RoleGate>
+        </template>
+        <template #empty>
+          <EmptyState
+            title="Sin recursos"
+            :message="hasFilters ? 'No hay recursos que coincidan con los filtros.' : 'Aún no hay tipos de recurso en el catálogo.'"
+          >
+            <template #icon><SearchX /></template>
+            <template #action>
+              <AppButton v-if="hasFilters" variant="outline" size="sm" @click="clearFilters"><RotateCcw /> Limpiar filtros</AppButton>
+              <RoleGate v-else :roles="[...EDIT_ROLES]">
+                <AppButton size="sm" @click="openCreate"><Plus /> Nuevo recurso</AppButton>
+              </RoleGate>
+            </template>
+          </EmptyState>
+        </template>
+      </DataTable>
+    </div>
+
+    <BaseModal
+      :open="modalOpen"
+      :title="editId != null ? 'Editar recurso' : 'Nuevo recurso'"
+      max-width="max-w-[520px]"
+      @close="modalOpen = false"
+    >
+      <form class="space-y-4" @submit.prevent="submit">
+        <FormField label="Nombre" required :error="errors.name" input-id="rt-name">
+          <input id="rt-name" v-model="form.name" class="control" placeholder="Ej. Kit alimentario" />
+        </FormField>
+        <SelectField v-model="form.category" label="Categoría" required :options="categoryFormOptions" :error="errors.category" input-id="rt-cat" />
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <FormField label="Unidad de medida" required :error="errors.unit_of_measure" input-id="rt-unit" hint="Ej. unidad, kg, caja">
+            <input id="rt-unit" v-model="form.unit_of_measure" class="control" placeholder="unidad" />
+          </FormField>
+          <FormField label="Peso unitario (kg)" required :error="errors.unit_weight_kg" input-id="rt-weight">
+            <input id="rt-weight" v-model="form.unit_weight_kg" type="number" min="0" step="any" class="control" placeholder="0" />
+          </FormField>
+        </div>
+      </form>
+      <template #footer>
+        <AppButton variant="ghost" @click="modalOpen = false">Cancelar</AppButton>
+        <AppButton :disabled="saving" @click="submit">
+          {{ saving ? 'Guardando…' : editId != null ? 'Guardar cambios' : 'Crear recurso' }}
+        </AppButton>
+      </template>
+    </BaseModal>
+
+    <ConfirmDialog
+      :open="confirmOpen"
+      tone="warning"
+      title="Desactivar recurso"
+      :message="target ? `“${target.name}” quedará inactivo (no se elimina, para preservar el histórico). Podrás reactivarlo luego.` : ''"
+      confirm-label="Desactivar"
+      @confirm="confirmDeactivate"
+      @close="confirmOpen = false"
+    />
+  </section>
+</template>

--- a/client/src/pages/settings/AlertThresholdsPage.vue
+++ b/client/src/pages/settings/AlertThresholdsPage.vue
@@ -1,0 +1,130 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { toast } from 'vue-sonner'
+import { Save, RotateCcw, SlidersHorizontal } from '@lucide/vue'
+import { useResourceTypes } from '@/composables/useResourceTypes'
+import { useAlertThresholds, useThresholdMutations } from '@/composables/useInventory'
+import { RESOURCE_CATEGORY_LABELS } from '@/types/inventory.types'
+import type { ResourceType, ResourceTypeListParams } from '@/types/inventory.types'
+import { apiErrorMessage } from '@/utils/apiError'
+import PageHeader from '@/components/ui/PageHeader.vue'
+import AppButton from '@/components/ui/AppButton.vue'
+import DataTable from '@/components/ui/DataTable.vue'
+import EmptyState from '@/components/ui/EmptyState.vue'
+import SkeletonBlock from '@/components/ui/SkeletonBlock.vue'
+
+const activeParams = ref<ResourceTypeListParams>({ is_active: true })
+const { data: resourceTypes, isLoading: loadingRt, isError } = useResourceTypes(activeParams)
+const { data: thresholds, isLoading: loadingTh } = useAlertThresholds()
+const { setThreshold } = useThresholdMutations()
+
+const loading = computed(() => loadingRt.value || loadingTh.value)
+const thresholdMap = computed(
+  () => new Map((thresholds.value ?? []).map((t) => [t.resource_type_id, t.min_quantity])),
+)
+interface Row { id: number; rt: ResourceType; saved: number | null }
+const rows = computed<Row[]>(() =>
+  (resourceTypes.value ?? []).map((rt) => ({ id: rt.id, rt, saved: thresholdMap.value.get(rt.id) ?? null })),
+)
+const asRow = (r: unknown) => r as Row
+
+// Valores en edición por recurso (se limpian tras guardar para reflejar lo guardado).
+const draft = ref<Record<number, string>>({})
+const savingId = ref<number | null>(null)
+
+function inputVal(row: Row) {
+  return draft.value[row.rt.id] ?? (row.saved != null ? String(row.saved) : '')
+}
+function onInput(id: number, v: string) {
+  draft.value[id] = v
+}
+function isDirty(row: Row) {
+  const d = draft.value[row.rt.id]
+  if (d === undefined || d === '') return false
+  const n = Number(d)
+  return !Number.isNaN(n) && n >= 0 && n !== (row.saved ?? -1)
+}
+async function save(row: Row) {
+  const d = draft.value[row.rt.id]
+  const n = Number(d)
+  if (d === '' || d === undefined || Number.isNaN(n) || n < 0 || !Number.isInteger(n)) {
+    toast.error('Ingresa un entero válido (≥ 0).')
+    return
+  }
+  savingId.value = row.rt.id
+  try {
+    await setThreshold.mutateAsync({ resource_type_id: row.rt.id, min_quantity: n })
+    toast.success(`Umbral de “${row.rt.name}” actualizado`)
+    delete draft.value[row.rt.id]
+  } catch (e) {
+    toast.error(apiErrorMessage(e))
+  } finally {
+    savingId.value = null
+  }
+}
+
+const columns = [
+  { key: 'resource', label: 'Recurso' },
+  { key: 'unit', label: 'Unidad' },
+  { key: 'threshold', label: 'Umbral mínimo' },
+  { key: 'actions', label: '', align: 'right' as const },
+]
+</script>
+
+<template>
+  <section class="space-y-5">
+    <PageHeader
+      title="Umbrales de alerta"
+      crumb="Configuración"
+      subtitle="Cantidad mínima por recurso antes de generar alerta de stock bajo (HU-16)"
+    />
+
+    <div v-if="isError" class="rounded-lg border border-danger-br bg-danger-bg p-6 text-center text-sm text-danger">
+      No se pudieron cargar los umbrales.
+    </div>
+
+    <div v-else-if="loading" class="space-y-2 rounded-lg border border-neutral-200 bg-white p-4">
+      <SkeletonBlock v-for="n in 6" :key="n" height="44px" />
+    </div>
+
+    <DataTable v-else :columns="columns" :rows="rows" row-key="id" min-width="640px">
+      <template #resource="{ row }">
+        <div>
+          <p class="font-medium text-neutral-900">{{ asRow(row).rt.name }}</p>
+          <p class="text-xs text-neutral-500">{{ RESOURCE_CATEGORY_LABELS[asRow(row).rt.category] }}</p>
+        </div>
+      </template>
+      <template #unit="{ row }"><span class="text-neutral-600">{{ asRow(row).rt.unit_of_measure }}</span></template>
+      <template #threshold="{ row }">
+        <input
+          type="number"
+          min="0"
+          step="1"
+          class="control max-w-[160px]"
+          :value="inputVal(asRow(row))"
+          :placeholder="asRow(row).saved == null ? 'Sin umbral' : ''"
+          @input="onInput(asRow(row).rt.id, ($event.target as HTMLInputElement).value)"
+        />
+      </template>
+      <template #actions="{ row }">
+        <AppButton
+          variant="outline"
+          size="sm"
+          :disabled="!isDirty(asRow(row)) || savingId === asRow(row).rt.id"
+          @click="save(asRow(row))"
+        >
+          <Save /> {{ savingId === asRow(row).rt.id ? 'Guardando…' : 'Guardar' }}
+        </AppButton>
+      </template>
+      <template #empty>
+        <EmptyState title="Sin recursos activos" message="Crea tipos de recurso para configurar sus umbrales de alerta.">
+          <template #icon><SlidersHorizontal /></template>
+        </EmptyState>
+      </template>
+    </DataTable>
+
+    <p class="flex items-center gap-2 text-xs text-neutral-400">
+      <RotateCcw class="h-3.5 w-3.5" /> Los cambios se aplican al guardar cada fila.
+    </p>
+  </section>
+</template>

--- a/client/src/pages/warehouses/WarehouseDetailPage.vue
+++ b/client/src/pages/warehouses/WarehouseDetailPage.vue
@@ -1,0 +1,286 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { toast } from 'vue-sonner'
+import {
+  ArrowLeft, PackagePlus, SlidersHorizontal, RotateCcw, PackageOpen, TriangleAlert,
+} from '@lucide/vue'
+import { useWarehouse, useWarehouseInventory } from '@/composables/useWarehouses'
+import { useInventoryMutations } from '@/composables/useInventory'
+import { useResourceTypes } from '@/composables/useResourceTypes'
+import { useZones } from '@/composables/useZones'
+import { RESOURCE_CATEGORY_LABELS, ADJUSTMENT_REASON_OPTIONS } from '@/types/inventory.types'
+import type { AdjustInventoryPayload, InventoryRow, UpsertInventoryPayload } from '@/types/inventory.types'
+import type { ResourceTypeListParams } from '@/types/inventory.types'
+import { upsertInventorySchema, adjustmentSchema } from '@/schemas/inventory.schema'
+import { validate } from '@/utils/validation'
+import { apiErrorMessage } from '@/utils/apiError'
+import PageHeader from '@/components/ui/PageHeader.vue'
+import AppButton from '@/components/ui/AppButton.vue'
+import DataTable from '@/components/ui/DataTable.vue'
+import EmptyState from '@/components/ui/EmptyState.vue'
+import SkeletonBlock from '@/components/ui/SkeletonBlock.vue'
+import ProgressBar from '@/components/ui/ProgressBar.vue'
+import BaseModal from '@/components/ui/BaseModal.vue'
+import FormField from '@/components/form/FormField.vue'
+import SelectField from '@/components/form/SelectField.vue'
+import RoleGate from '@/components/auth/RoleGate.vue'
+
+const route = useRoute()
+const router = useRouter()
+const warehouseId = computed(() => Number(route.params.id))
+const EDIT_ROLES = ['ADMIN', 'COORDINADOR_LOGISTICA'] as const
+
+const { data: warehouse, isLoading, isError, refetch } = useWarehouse(warehouseId)
+const { data: inventory, isLoading: loadingInv } = useWarehouseInventory(warehouseId)
+const { data: zones } = useZones()
+const activeResourceParams = ref<ResourceTypeListParams>({ is_active: true })
+const { data: resourceTypes } = useResourceTypes(activeResourceParams)
+const { upsert, adjust } = useInventoryMutations()
+
+const zoneName = computed(() => (zones.value ?? []).find((z) => z.id === warehouse.value?.zone_id)?.name ?? '—')
+const usagePct = computed(() =>
+  warehouse.value && warehouse.value.max_capacity_kg > 0
+    ? (warehouse.value.current_weight_kg / warehouse.value.max_capacity_kg) * 100
+    : 0,
+)
+const kg = (n: number) => `${Math.round(n).toLocaleString('es-CO')} kg`
+const asRow = (r: unknown) => r as InventoryRow
+
+const resourceOptions = computed(() => [
+  { value: '', label: 'Selecciona el recurso…' },
+  ...(resourceTypes.value ?? []).map((rt) => ({ value: String(rt.id), label: `${rt.name} (${rt.unit_of_measure})` })),
+])
+
+const columns = [
+  { key: 'resource', label: 'Recurso' },
+  { key: 'quantity', label: 'Disponible', align: 'right' as const },
+  { key: 'weight', label: 'Peso', align: 'right' as const },
+  { key: 'batch', label: 'Lote' },
+  { key: 'expiration', label: 'Vence' },
+  { key: 'actions', label: '', align: 'right' as const },
+]
+
+function fmtDate(s: string | null) {
+  return s ? new Date(s).toLocaleDateString('es-CO', { day: '2-digit', month: 'short', year: 'numeric' }) : '—'
+}
+function daysUntil(s: string) {
+  return Math.ceil((new Date(s).getTime() - Date.now()) / 86400000)
+}
+// Resaltado de vencimientos: rojo vencido, ámbar ≤30 días (HU-17).
+function expiryClass(row: InventoryRow) {
+  if (!row.expiration_date) return 'text-neutral-400'
+  if (row.is_expired) return 'text-danger font-semibold'
+  return daysUntil(row.expiration_date) <= 30 ? 'text-warning font-medium' : 'text-neutral-700'
+}
+
+// --- Agregar stock ------------------------------------------------------------
+const addOpen = ref(false)
+const addErrors = ref<Record<string, string>>({})
+const adding = computed(() => upsert.isPending.value)
+function blankAdd() {
+  return { resource_type_id: '', quantity: '', batch: '', expiration_date: '' }
+}
+const addForm = ref(blankAdd())
+function openAdd() {
+  addForm.value = blankAdd()
+  addErrors.value = {}
+  addOpen.value = true
+}
+async function submitAdd() {
+  const res = validate(upsertInventorySchema, { ...addForm.value })
+  if (!res.ok) {
+    addErrors.value = res.errors
+    return
+  }
+  addErrors.value = {}
+  const payload: UpsertInventoryPayload = {
+    warehouse_id: warehouseId.value,
+    resource_type_id: res.data.resource_type_id,
+    quantity: res.data.quantity,
+    batch: res.data.batch?.trim() ? res.data.batch : null,
+    expiration_date: res.data.expiration_date || null,
+  }
+  try {
+    await upsert.mutateAsync(payload)
+    toast.success('Stock agregado')
+    addOpen.value = false
+  } catch (e) {
+    toast.error(apiErrorMessage(e, 'No se pudo agregar stock. ¿Supera la capacidad de la bodega?'))
+  }
+}
+
+// --- Ajustar ------------------------------------------------------------------
+const adjOpen = ref(false)
+const adjTarget = ref<InventoryRow | null>(null)
+const adjErrors = ref<Record<string, string>>({})
+const adjusting = computed(() => adjust.isPending.value)
+function blankAdj() {
+  return { delta: '', reason: '', reason_note: '' }
+}
+const adjForm = ref(blankAdj())
+const reasonOptions = [{ value: '', label: 'Selecciona el motivo…' }, ...ADJUSTMENT_REASON_OPTIONS]
+
+function openAdjust(row: InventoryRow) {
+  adjTarget.value = row
+  adjForm.value = blankAdj()
+  adjErrors.value = {}
+  adjOpen.value = true
+}
+async function submitAdjust() {
+  if (!adjTarget.value) return
+  const res = validate(adjustmentSchema, { ...adjForm.value })
+  if (!res.ok) {
+    adjErrors.value = res.errors
+    return
+  }
+  adjErrors.value = {}
+  const payload: AdjustInventoryPayload = {
+    delta: res.data.delta,
+    reason: res.data.reason,
+    reason_note: res.data.reason_note,
+  }
+  try {
+    await adjust.mutateAsync({ id: adjTarget.value.id, payload })
+    toast.success('Ajuste aplicado')
+    adjOpen.value = false
+  } catch (e) {
+    toast.error(apiErrorMessage(e, 'No se pudo ajustar: el resultado no puede dejar stock negativo (HU-17).'))
+  }
+}
+</script>
+
+<template>
+  <section class="space-y-5">
+    <div v-if="isLoading" class="space-y-4">
+      <SkeletonBlock height="120px" />
+      <SkeletonBlock height="200px" />
+    </div>
+    <div v-else-if="isError || !warehouse" class="rounded-lg border border-danger-br bg-danger-bg p-6 text-center">
+      <p class="text-sm text-danger">No se pudo cargar la bodega.</p>
+      <AppButton variant="outline" size="sm" class="mt-3" @click="() => refetch()"><RotateCcw /> Reintentar</AppButton>
+    </div>
+
+    <template v-else>
+      <PageHeader :title="warehouse.name" :crumb="`Bodegas · ${warehouse.address}`">
+        <template #actions>
+          <AppButton variant="outline" @click="router.push('/warehouses')"><ArrowLeft /> Volver</AppButton>
+          <RoleGate :roles="[...EDIT_ROLES]">
+            <AppButton @click="openAdd"><PackagePlus /> Agregar stock</AppButton>
+          </RoleGate>
+        </template>
+      </PageHeader>
+
+      <!-- Resumen de capacidad -->
+      <div class="rounded-lg border border-neutral-200 bg-white p-5">
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <div>
+            <p class="text-sm text-neutral-500">Zona</p>
+            <p class="font-medium text-neutral-900">{{ zoneName }}</p>
+          </div>
+          <div>
+            <p class="text-sm text-neutral-500">Peso almacenado</p>
+            <p class="font-medium text-neutral-900">{{ kg(warehouse.current_weight_kg) }} / {{ kg(warehouse.max_capacity_kg) }}</p>
+          </div>
+          <div class="flex items-center gap-2">
+            <div class="flex-1">
+              <ProgressBar :value="usagePct" :ok="16" :warn="1" invert label="Uso de capacidad" />
+            </div>
+            <span v-if="warehouse.is_over_85_percent" class="mt-4 inline-flex items-center gap-1 text-xs font-semibold text-warning">
+              <TriangleAlert class="h-3.5 w-3.5" /> 85%
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Inventario -->
+      <div v-if="loadingInv" class="space-y-2 rounded-lg border border-neutral-200 bg-white p-4">
+        <SkeletonBlock v-for="n in 4" :key="n" height="40px" />
+      </div>
+      <DataTable v-else :columns="columns" :rows="inventory ?? []" row-key="id" min-width="820px">
+        <template #resource="{ row }">
+          <div>
+            <p class="font-medium text-neutral-900">{{ asRow(row).resource.name }}</p>
+            <p class="text-xs text-neutral-500">{{ RESOURCE_CATEGORY_LABELS[asRow(row).resource.category] }}</p>
+          </div>
+        </template>
+        <template #quantity="{ row }">
+          <span class="font-mono">{{ asRow(row).available_quantity }}</span>
+          <span class="text-xs text-neutral-500"> {{ asRow(row).resource.unit_of_measure }}</span>
+        </template>
+        <template #weight="{ row }"><span class="font-mono text-xs">{{ kg(asRow(row).total_weight_kg) }}</span></template>
+        <template #batch="{ row }"><span class="text-sm text-neutral-600">{{ asRow(row).batch || '—' }}</span></template>
+        <template #expiration="{ row }">
+          <span :class="['text-sm', expiryClass(asRow(row))]">
+            {{ fmtDate(asRow(row).expiration_date) }}
+            <span v-if="asRow(row).is_expired"> · vencido</span>
+          </span>
+        </template>
+        <template #actions="{ row }">
+          <RoleGate :roles="[...EDIT_ROLES]">
+            <AppButton variant="ghost" size="sm" @click="openAdjust(asRow(row))"><SlidersHorizontal /> Ajustar</AppButton>
+          </RoleGate>
+        </template>
+        <template #empty>
+          <EmptyState title="Sin existencias" message="Esta bodega no tiene inventario registrado.">
+            <template #icon><PackageOpen /></template>
+            <template #action>
+              <RoleGate :roles="[...EDIT_ROLES]">
+                <AppButton size="sm" @click="openAdd"><PackagePlus /> Agregar stock</AppButton>
+              </RoleGate>
+            </template>
+          </EmptyState>
+        </template>
+      </DataTable>
+    </template>
+
+    <!-- Modal agregar stock -->
+    <BaseModal :open="addOpen" title="Agregar stock" max-width="max-w-[520px]" @close="addOpen = false">
+      <form class="space-y-4" @submit.prevent="submitAdd">
+        <SelectField v-model="addForm.resource_type_id" label="Recurso" required :options="resourceOptions" :error="addErrors.resource_type_id" input-id="add-rt" />
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <FormField label="Cantidad" required :error="addErrors.quantity" input-id="add-qty">
+            <input id="add-qty" v-model="addForm.quantity" type="number" min="1" class="control" placeholder="0" />
+          </FormField>
+          <FormField label="Lote" :error="addErrors.batch" input-id="add-batch" hint="Opcional">
+            <input id="add-batch" v-model="addForm.batch" class="control" placeholder="Ej. L-2026-01" />
+          </FormField>
+        </div>
+        <FormField label="Fecha de vencimiento" :error="addErrors.expiration_date" input-id="add-exp" hint="Opcional (solo perecederos)">
+          <input id="add-exp" v-model="addForm.expiration_date" type="date" class="control" />
+        </FormField>
+      </form>
+      <template #footer>
+        <AppButton variant="ghost" @click="addOpen = false">Cancelar</AppButton>
+        <AppButton :disabled="adding" @click="submitAdd">{{ adding ? 'Guardando…' : 'Agregar' }}</AppButton>
+      </template>
+    </BaseModal>
+
+    <!-- Modal ajustar -->
+    <BaseModal :open="adjOpen" title="Ajustar existencias" max-width="max-w-[520px]" @close="adjOpen = false">
+      <form v-if="adjTarget" class="space-y-4" @submit.prevent="submitAdjust">
+        <p class="text-sm text-neutral-600">
+          <strong class="text-neutral-900">{{ adjTarget.resource.name }}</strong> ·
+          disponible: {{ adjTarget.available_quantity }} {{ adjTarget.resource.unit_of_measure }}.
+        </p>
+        <FormField
+          label="Ajuste (delta)"
+          required
+          :error="adjErrors.delta"
+          input-id="adj-delta"
+          hint="Positivo suma, negativo resta. El resultado no puede ser negativo."
+        >
+          <input id="adj-delta" v-model="adjForm.delta" type="number" step="1" class="control" placeholder="Ej. -5" />
+        </FormField>
+        <SelectField v-model="adjForm.reason" label="Motivo" required :options="reasonOptions" :error="adjErrors.reason" input-id="adj-reason" />
+        <FormField label="Nota / justificación" required :error="adjErrors.reason_note" input-id="adj-note" hint="Obligatoria (HU-17 CA2).">
+          <textarea id="adj-note" v-model="adjForm.reason_note" class="control" rows="3" placeholder="Describe el motivo del ajuste…" />
+        </FormField>
+      </form>
+      <template #footer>
+        <AppButton variant="ghost" @click="adjOpen = false">Cancelar</AppButton>
+        <AppButton :disabled="adjusting" @click="submitAdjust">{{ adjusting ? 'Aplicando…' : 'Aplicar ajuste' }}</AppButton>
+      </template>
+    </BaseModal>
+  </section>
+</template>

--- a/client/src/pages/warehouses/WarehousesListPage.vue
+++ b/client/src/pages/warehouses/WarehousesListPage.vue
@@ -1,0 +1,348 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { toast } from 'vue-sonner'
+import {
+  Plus, Pencil, Trash2, Eye, SearchX, RotateCcw, ChevronLeft, ChevronRight, TriangleAlert,
+} from '@lucide/vue'
+import { useWarehousesList, useWarehouseMutations } from '@/composables/useWarehouses'
+import { useZones } from '@/composables/useZones'
+import { WAREHOUSE_STATUS_OPTIONS, WAREHOUSE_STATUS_LABELS } from '@/types/warehouse.types'
+import type {
+  WarehouseListParams, WarehousePayload, WarehouseStatus, WarehouseWithOccupancy,
+} from '@/types/warehouse.types'
+import { warehouseSchema } from '@/schemas/warehouse.schema'
+import { validate } from '@/utils/validation'
+import { apiErrorMessage } from '@/utils/apiError'
+import PageHeader from '@/components/ui/PageHeader.vue'
+import AppButton from '@/components/ui/AppButton.vue'
+import DataTable from '@/components/ui/DataTable.vue'
+import EmptyState from '@/components/ui/EmptyState.vue'
+import SkeletonBlock from '@/components/ui/SkeletonBlock.vue'
+import ProgressBar from '@/components/ui/ProgressBar.vue'
+import BaseModal from '@/components/ui/BaseModal.vue'
+import ConfirmDialog from '@/components/ui/ConfirmDialog.vue'
+import SearchInput from '@/components/form/SearchInput.vue'
+import SelectField from '@/components/form/SelectField.vue'
+import FormField from '@/components/form/FormField.vue'
+import MapPicker from '@/components/form/MapPicker.vue'
+import RoleGate from '@/components/auth/RoleGate.vue'
+
+const router = useRouter()
+const PAGE_SIZE = 20
+const EDIT_ROLES = ['ADMIN', 'COORDINADOR_LOGISTICA'] as const
+
+const search = ref('')
+const zoneFilter = ref('')
+const statusFilter = ref('')
+const page = ref(1)
+
+const params = computed<WarehouseListParams>(() => ({
+  page: page.value,
+  limit: PAGE_SIZE,
+  ...(search.value ? { search: search.value } : {}),
+  ...(zoneFilter.value ? { zone_id: Number(zoneFilter.value) } : {}),
+  ...(statusFilter.value ? { status: statusFilter.value as WarehouseStatus } : {}),
+}))
+
+const { data, isLoading, isFetching, isError, refetch } = useWarehousesList(params)
+const { data: zones } = useZones()
+
+const zoneMap = computed(() => new Map((zones.value ?? []).map((z) => [z.id, z])))
+const rows = computed(() => data.value?.data ?? [])
+const total = computed(() => data.value?.pagination.total ?? 0)
+const totalPages = computed(() => data.value?.pagination.totalPages ?? 1)
+const rangeFrom = computed(() => (total.value === 0 ? 0 : (page.value - 1) * PAGE_SIZE + 1))
+const rangeTo = computed(() => Math.min(page.value * PAGE_SIZE, total.value))
+const hasFilters = computed(() => !!(search.value || zoneFilter.value || statusFilter.value))
+
+const zoneFilterOptions = computed(() => [
+  { value: '', label: 'Todas las zonas' },
+  ...(zones.value ?? []).map((z) => ({ value: String(z.id), label: z.name })),
+])
+const zoneFormOptions = computed(() => [
+  { value: '', label: 'Selecciona la zona…' },
+  ...(zones.value ?? []).map((z) => ({ value: String(z.id), label: z.name })),
+])
+const statusFilterOptions = [{ value: '', label: 'Todos los estados' }, ...WAREHOUSE_STATUS_OPTIONS.map((o) => ({ value: o.value as string, label: o.label }))]
+const statusFormOptions = WAREHOUSE_STATUS_OPTIONS.map((o) => ({ value: o.value as string, label: o.label }))
+
+const columns = [
+  { key: 'name', label: 'Bodega' },
+  { key: 'zone', label: 'Zona' },
+  { key: 'capacity', label: 'Peso / capacidad', align: 'right' as const },
+  { key: 'usage', label: 'Uso' },
+  { key: 'status', label: 'Estado', align: 'center' as const },
+  { key: 'actions', label: '', align: 'right' as const },
+]
+
+const asWarehouse = (r: unknown) => r as WarehouseWithOccupancy
+const usagePct = (w: WarehouseWithOccupancy) =>
+  w.max_capacity_kg > 0 ? (w.current_weight_kg / w.max_capacity_kg) * 100 : 0
+const kg = (n: number) => `${Math.round(n).toLocaleString('es-CO')} kg`
+
+function goTo(p: number) {
+  page.value = Math.min(Math.max(1, p), totalPages.value)
+}
+function clearFilters() {
+  search.value = ''
+  zoneFilter.value = ''
+  statusFilter.value = ''
+}
+
+// --- Modal crear / editar -----------------------------------------------------
+const { create, update, remove } = useWarehouseMutations()
+const saving = computed(() => create.isPending.value || update.isPending.value)
+const modalOpen = ref(false)
+const editId = ref<number | null>(null)
+const errors = ref<Record<string, string>>({})
+function blankForm() {
+  return {
+    name: '',
+    address: '',
+    zone_id: '',
+    max_capacity_kg: '',
+    status: 'ACTIVE' as WarehouseStatus,
+    latitude: null as number | null,
+    longitude: null as number | null,
+  }
+}
+const form = ref(blankForm())
+
+function openCreate() {
+  editId.value = null
+  form.value = blankForm()
+  errors.value = {}
+  modalOpen.value = true
+}
+function openEdit(w: WarehouseWithOccupancy) {
+  editId.value = w.id
+  form.value = {
+    name: w.name,
+    address: w.address,
+    zone_id: String(w.zone_id),
+    max_capacity_kg: String(w.max_capacity_kg),
+    status: w.status,
+    latitude: w.latitude,
+    longitude: w.longitude,
+  }
+  errors.value = {}
+  modalOpen.value = true
+}
+
+async function submit() {
+  const res = validate(warehouseSchema, {
+    name: form.value.name,
+    address: form.value.address,
+    zone_id: form.value.zone_id,
+    max_capacity_kg: form.value.max_capacity_kg,
+    status: form.value.status,
+  })
+  const errs: Record<string, string> = res.ok ? {} : { ...res.errors }
+  if (form.value.latitude == null || form.value.longitude == null) {
+    errs.location = 'Ubica la bodega en el mapa (obligatorio).'
+  }
+  errors.value = errs
+  if (!res.ok || errs.location) return
+
+  const payload: WarehousePayload = {
+    name: res.data.name,
+    address: res.data.address,
+    zone_id: res.data.zone_id,
+    max_capacity_kg: res.data.max_capacity_kg,
+    status: res.data.status,
+    latitude: form.value.latitude!,
+    longitude: form.value.longitude!,
+  }
+  try {
+    if (editId.value != null) await update.mutateAsync({ id: editId.value, payload })
+    else await create.mutateAsync(payload)
+    toast.success(editId.value != null ? 'Bodega actualizada' : 'Bodega creada')
+    modalOpen.value = false
+  } catch (e) {
+    toast.error(apiErrorMessage(e))
+  }
+}
+
+// --- Eliminar -----------------------------------------------------------------
+const confirmOpen = ref(false)
+const target = ref<WarehouseWithOccupancy | null>(null)
+function askDelete(w: WarehouseWithOccupancy) {
+  target.value = w
+  confirmOpen.value = true
+}
+async function confirmDelete() {
+  if (!target.value) return
+  try {
+    await remove.mutateAsync(target.value.id)
+    toast.success('Bodega eliminada')
+  } catch (e) {
+    toast.error(apiErrorMessage(e, 'No se pudo eliminar: la bodega puede tener inventario asociado.'))
+  } finally {
+    confirmOpen.value = false
+    target.value = null
+  }
+}
+</script>
+
+<template>
+  <section class="space-y-5">
+    <PageHeader
+      title="Bodegas"
+      crumb="Logística"
+      :subtitle="total ? `${total} ${total === 1 ? 'bodega' : 'bodegas'}` : 'Capacidad y almacenamiento de ayudas'"
+    >
+      <template #actions>
+        <RoleGate :roles="[...EDIT_ROLES]">
+          <AppButton @click="openCreate"><Plus /> Agregar bodega</AppButton>
+        </RoleGate>
+      </template>
+    </PageHeader>
+
+    <!-- Filtros -->
+    <div class="grid grid-cols-1 gap-3 rounded-lg border border-neutral-200 bg-white p-4 sm:grid-cols-3">
+      <SearchInput v-model="search" placeholder="Buscar por nombre o dirección…" />
+      <SelectField v-model="zoneFilter" :options="zoneFilterOptions" />
+      <SelectField v-model="statusFilter" :options="statusFilterOptions" />
+    </div>
+
+    <div v-if="isError" class="rounded-lg border border-danger-br bg-danger-bg p-6 text-center">
+      <p class="text-sm text-danger">No se pudieron cargar las bodegas.</p>
+      <AppButton variant="outline" size="sm" class="mt-3" @click="() => refetch()"><RotateCcw /> Reintentar</AppButton>
+    </div>
+
+    <div v-else-if="isLoading" class="space-y-2 rounded-lg border border-neutral-200 bg-white p-4">
+      <SkeletonBlock v-for="n in 6" :key="n" height="44px" />
+    </div>
+
+    <template v-else>
+      <div :class="{ 'opacity-60 transition-opacity': isFetching }">
+        <DataTable :columns="columns" :rows="rows" row-key="id" min-width="900px">
+          <template #name="{ row }">
+            <div>
+              <p class="font-semibold text-neutral-900">{{ asWarehouse(row).name }}</p>
+              <p class="text-xs text-neutral-500">{{ asWarehouse(row).address }}</p>
+            </div>
+          </template>
+
+          <template #zone="{ row }">{{ zoneMap.get(asWarehouse(row).zone_id)?.name ?? '—' }}</template>
+
+          <template #capacity="{ row }">
+            <span class="font-mono text-xs">{{ kg(asWarehouse(row).current_weight_kg) }} / {{ kg(asWarehouse(row).max_capacity_kg) }}</span>
+          </template>
+
+          <template #usage="{ row }">
+            <div class="flex min-w-[150px] items-center gap-2">
+              <div class="flex-1"><ProgressBar :value="usagePct(asWarehouse(row))" :ok="16" :warn="1" invert /></div>
+              <span
+                v-if="asWarehouse(row).is_over_85_percent"
+                class="inline-flex items-center gap-1 text-xs font-semibold text-warning"
+                title="Capacidad sobre el 85% (HU-11)"
+              >
+                <TriangleAlert class="h-3.5 w-3.5" /> 85%
+              </span>
+            </div>
+          </template>
+
+          <template #status="{ row }">
+            <span
+              :class="[
+                'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-semibold',
+                asWarehouse(row).status === 'ACTIVE'
+                  ? 'border-success-br bg-success-bg text-success'
+                  : 'border-neutral-200 bg-neutral-100 text-neutral-500',
+              ]"
+            >
+              {{ WAREHOUSE_STATUS_LABELS[asWarehouse(row).status] }}
+            </span>
+          </template>
+
+          <template #actions="{ row }">
+            <div class="flex justify-end gap-1">
+              <AppButton variant="ghost" size="sm" @click="router.push(`/warehouses/${asWarehouse(row).id}`)">
+                <Eye /> Ver
+              </AppButton>
+              <RoleGate :roles="[...EDIT_ROLES]">
+                <AppButton variant="ghost" size="sm" @click="openEdit(asWarehouse(row))"><Pencil /></AppButton>
+              </RoleGate>
+              <RoleGate :roles="[...EDIT_ROLES]">
+                <AppButton variant="ghost" size="sm" class="text-danger" @click="askDelete(asWarehouse(row))"><Trash2 /></AppButton>
+              </RoleGate>
+            </div>
+          </template>
+
+          <template #empty>
+            <EmptyState
+              title="Sin bodegas"
+              :message="hasFilters ? 'No hay bodegas que coincidan con los filtros.' : 'Aún no se han registrado bodegas.'"
+            >
+              <template #icon><SearchX /></template>
+              <template #action>
+                <AppButton v-if="hasFilters" variant="outline" size="sm" @click="clearFilters"><RotateCcw /> Limpiar filtros</AppButton>
+                <RoleGate v-else :roles="[...EDIT_ROLES]">
+                  <AppButton size="sm" @click="openCreate"><Plus /> Agregar bodega</AppButton>
+                </RoleGate>
+              </template>
+            </EmptyState>
+          </template>
+        </DataTable>
+      </div>
+
+      <div v-if="total > 0" class="flex flex-wrap items-center justify-between gap-3 text-sm text-neutral-600">
+        <span>Mostrando <strong>{{ rangeFrom }}–{{ rangeTo }}</strong> de <strong>{{ total }}</strong></span>
+        <div class="flex items-center gap-2">
+          <AppButton variant="outline" size="sm" :disabled="page <= 1" @click="goTo(page - 1)"><ChevronLeft /></AppButton>
+          <span class="px-1">Página {{ page }} de {{ totalPages }}</span>
+          <AppButton variant="outline" size="sm" :disabled="page >= totalPages" @click="goTo(page + 1)"><ChevronRight /></AppButton>
+        </div>
+      </div>
+    </template>
+
+    <!-- Modal crear / editar -->
+    <BaseModal
+      :open="modalOpen"
+      :title="editId != null ? 'Editar bodega' : 'Nueva bodega'"
+      max-width="max-w-[620px]"
+      @close="modalOpen = false"
+    >
+      <form class="space-y-4" @submit.prevent="submit">
+        <FormField label="Nombre" required :error="errors.name" input-id="wh-name">
+          <input id="wh-name" v-model="form.name" class="control" placeholder="Ej. Bodega Central" />
+        </FormField>
+        <FormField label="Dirección" required :error="errors.address" input-id="wh-address">
+          <input id="wh-address" v-model="form.address" class="control" placeholder="Calle 1 # 2-34" />
+        </FormField>
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <SelectField v-model="form.zone_id" label="Zona" required :options="zoneFormOptions" :error="errors.zone_id" input-id="wh-zone" />
+          <SelectField v-model="form.status" label="Estado" required :options="statusFormOptions" :error="errors.status" input-id="wh-status" />
+        </div>
+        <FormField label="Capacidad máxima (kg)" required :error="errors.max_capacity_kg" input-id="wh-cap">
+          <input id="wh-cap" v-model="form.max_capacity_kg" type="number" min="1" step="any" class="control" placeholder="0" />
+        </FormField>
+        <FormField
+          label="Ubicación"
+          required
+          :error="errors.location"
+          hint="Obligatoria (HU-11 CA2). Toca el mapa para colocar el marcador."
+        >
+          <MapPicker v-model:latitude="form.latitude" v-model:longitude="form.longitude" height="260px" />
+        </FormField>
+      </form>
+      <template #footer>
+        <AppButton variant="ghost" @click="modalOpen = false">Cancelar</AppButton>
+        <AppButton :disabled="saving" @click="submit">
+          {{ saving ? 'Guardando…' : editId != null ? 'Guardar cambios' : 'Crear bodega' }}
+        </AppButton>
+      </template>
+    </BaseModal>
+
+    <ConfirmDialog
+      :open="confirmOpen"
+      title="Eliminar bodega"
+      :message="target ? `¿Eliminar la bodega “${target.name}”? Esta acción no se puede deshacer.` : ''"
+      confirm-label="Eliminar"
+      @confirm="confirmDelete"
+      @close="confirmOpen = false"
+    />
+  </section>
+</template>

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -81,6 +81,40 @@ const router = createRouter({
           component: () => import('@/pages/shelters/SheltersListPage.vue'),
           meta: { roles: ['ADMIN', 'COORDINADOR_LOGISTICA'] },
         },
+        // Logística — Bodegas e Inventario (HU-11/14/15/16/17).
+        {
+          path: 'warehouses',
+          name: 'warehouses',
+          component: () => import('@/pages/warehouses/WarehousesListPage.vue'),
+          meta: { roles: ['ADMIN', 'COORDINADOR_LOGISTICA'] },
+        },
+        {
+          path: 'warehouses/:id',
+          name: 'warehouse-detail',
+          component: () => import('@/pages/warehouses/WarehouseDetailPage.vue'),
+          meta: { roles: ['ADMIN', 'COORDINADOR_LOGISTICA'] },
+        },
+        {
+          path: 'inventory/summary',
+          name: 'inventory-summary',
+          component: () => import('@/pages/inventory/InventorySummaryPage.vue'),
+        },
+        {
+          path: 'inventory/resource-types',
+          name: 'resource-types',
+          component: () => import('@/pages/inventory/ResourceTypesPage.vue'),
+        },
+        {
+          path: 'inventory/alerts',
+          name: 'inventory-alerts',
+          component: () => import('@/pages/inventory/InventoryAlertsPage.vue'),
+        },
+        {
+          path: 'settings/alerts',
+          name: 'settings-alerts',
+          component: () => import('@/pages/settings/AlertThresholdsPage.vue'),
+          meta: { roles: ['ADMIN', 'COORDINADOR_LOGISTICA'] },
+        },
         // Las demas rutas (entregas, mapa, etc.) se agregan aqui
         // a medida que se implementan las HU. Ver HistoriasDeUsuario.json.
       ],

--- a/client/src/schemas/inventory.schema.ts
+++ b/client/src/schemas/inventory.schema.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod'
+
+// Agregar stock a una bodega (upsert por lote). quantity es entero > 0.
+export const upsertInventorySchema = z.object({
+  resource_type_id: z.preprocess(
+    (v) => (v === '' || v === null || v === undefined ? undefined : Number(v)),
+    z.number({ message: 'Selecciona el recurso' }).int().min(1, 'Selecciona el recurso'),
+  ),
+  quantity: z.preprocess(
+    (v) => (v === '' || v === null || v === undefined ? undefined : Number(v)),
+    z.number({ message: 'Ingresa la cantidad' }).int('Debe ser un entero').positive('Debe ser mayor que 0'),
+  ),
+  batch: z.string().trim().max(60, 'Máximo 60 caracteres').optional(),
+  expiration_date: z.string().optional(),
+})
+
+export type UpsertInventoryValues = z.infer<typeof upsertInventorySchema>
+
+// Ajuste manual de existencias (HU-17): delta entero distinto de cero + motivo + nota.
+export const adjustmentSchema = z.object({
+  delta: z.preprocess(
+    (v) => (v === '' || v === null || v === undefined ? undefined : Number(v)),
+    z
+      .number({ message: 'Ingresa la cantidad a ajustar' })
+      .int('Debe ser un entero')
+      .refine((n) => n !== 0, 'No puede ser cero'),
+  ),
+  reason: z.enum(['MERMA', 'DANO', 'DEVOLUCION', 'CORRECCION'], { message: 'Selecciona el motivo' }),
+  reason_note: z.string().trim().min(3, 'Mínimo 3 caracteres').max(500, 'Máximo 500 caracteres'),
+})
+
+export type AdjustmentValues = z.infer<typeof adjustmentSchema>

--- a/client/src/schemas/resourceType.schema.ts
+++ b/client/src/schemas/resourceType.schema.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod'
+
+// Formulario del catálogo de tipos de recurso (HU-14).
+export const resourceTypeSchema = z.object({
+  name: z.string().trim().min(2, 'Mínimo 2 caracteres').max(120, 'Máximo 120 caracteres'),
+  category: z.enum(['FOOD', 'BLANKET', 'MATTRESS', 'HYGIENE', 'MEDICATION'], {
+    message: 'Selecciona la categoría',
+  }),
+  unit_of_measure: z.string().trim().min(1, 'Requerida').max(30, 'Máximo 30 caracteres'),
+  unit_weight_kg: z.preprocess(
+    (v) => (v === '' || v === null || v === undefined ? undefined : Number(v)),
+    z.number({ message: 'Ingresa el peso unitario' }).min(0, 'No puede ser negativo'),
+  ),
+})
+
+export type ResourceTypeFormValues = z.infer<typeof resourceTypeSchema>

--- a/client/src/schemas/warehouse.schema.ts
+++ b/client/src/schemas/warehouse.schema.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod'
+
+// Campos del formulario de bodega. La ubicación (lat/lng) se valida aparte en la
+// página: es obligatoria (RN-10, HU-11 CA2).
+export const warehouseSchema = z.object({
+  name: z.string().trim().min(2, 'Mínimo 2 caracteres').max(120, 'Máximo 120 caracteres'),
+  address: z.string().trim().min(3, 'Mínimo 3 caracteres').max(200, 'Máximo 200 caracteres'),
+  zone_id: z.preprocess(
+    (v) => (v === '' || v === null || v === undefined ? undefined : Number(v)),
+    z.number({ message: 'Selecciona la zona' }).int().min(1, 'Selecciona la zona'),
+  ),
+  max_capacity_kg: z.preprocess(
+    (v) => (v === '' || v === null || v === undefined ? undefined : Number(v)),
+    z.number({ message: 'Ingresa la capacidad' }).positive('Debe ser mayor que 0'),
+  ),
+  status: z.enum(['ACTIVE', 'INACTIVE']),
+})
+
+export type WarehouseFormValues = z.infer<typeof warehouseSchema>

--- a/client/src/types/inventory.types.ts
+++ b/client/src/types/inventory.types.ts
@@ -1,0 +1,153 @@
+// Tipos del dominio de inventario: catálogo de recursos, existencias, resumen,
+// alertas, umbrales y ajustes. Reflejan server/src/types/entities.ts.
+
+// --- Categorías de recurso ----------------------------------------------------
+export type ResourceCategory = 'FOOD' | 'BLANKET' | 'MATTRESS' | 'HYGIENE' | 'MEDICATION'
+
+export const RESOURCE_CATEGORY_OPTIONS: { value: ResourceCategory; label: string }[] = [
+  { value: 'FOOD', label: 'Alimentos' },
+  { value: 'BLANKET', label: 'Cobijas' },
+  { value: 'MATTRESS', label: 'Colchonetas' },
+  { value: 'HYGIENE', label: 'Higiene' },
+  { value: 'MEDICATION', label: 'Medicamentos' },
+]
+
+export const RESOURCE_CATEGORY_LABELS = Object.fromEntries(
+  RESOURCE_CATEGORY_OPTIONS.map((o) => [o.value, o.label]),
+) as Record<ResourceCategory, string>
+
+// --- Tipo de recurso (catálogo) -----------------------------------------------
+export interface ResourceType {
+  id: number
+  name: string
+  category: ResourceCategory
+  unit_of_measure: string
+  unit_weight_kg: number
+  is_active: boolean
+  created_at?: string
+  updated_at?: string
+}
+
+export interface ResourceTypeListParams {
+  category?: ResourceCategory
+  is_active?: boolean
+}
+
+export interface ResourceTypePayload {
+  name: string
+  category: ResourceCategory
+  unit_of_measure: string
+  unit_weight_kg: number
+}
+
+// --- Existencias --------------------------------------------------------------
+// Fila enriquecida que devuelven GET /inventory y /warehouses/:id/inventory.
+export interface InventoryRow {
+  id: number
+  warehouse_id: number
+  resource_type_id: number
+  available_quantity: number
+  total_weight_kg: number
+  batch: string | null
+  expiration_date: string | null
+  is_expired: boolean
+  resource: {
+    id: number
+    name: string
+    category: ResourceCategory
+    unit_of_measure: string
+    unit_weight_kg: number
+    is_active: boolean
+  }
+  created_at?: string
+  updated_at?: string
+}
+
+export interface InventoryListParams {
+  page: number
+  limit: number
+  warehouse_id?: number
+  resource_type_id?: number
+  category?: ResourceCategory
+  only_in_stock?: boolean
+}
+
+// total_quantity llega como string (BIGINT de pg).
+export interface InventorySummaryRow {
+  warehouse_id: number
+  warehouse_name: string
+  category: ResourceCategory | null
+  total_quantity: string
+  total_weight_kg: number
+}
+
+// --- Alertas ------------------------------------------------------------------
+export type AlertKind = 'LOW_STOCK' | 'EXPIRING_SOON' | 'EXPIRED' | 'WAREHOUSE_OVER_85'
+export type AlertSeverity = 'CRITICAL' | 'HIGH' | 'MEDIUM'
+
+export const ALERT_KIND_LABELS: Record<AlertKind, string> = {
+  LOW_STOCK: 'Stock bajo',
+  EXPIRING_SOON: 'Próximo a vencer',
+  EXPIRED: 'Vencido',
+  WAREHOUSE_OVER_85: 'Bodega sobre 85%',
+}
+
+export const ALERT_SEVERITY_LABELS: Record<AlertSeverity, string> = {
+  CRITICAL: 'Crítica',
+  HIGH: 'Alta',
+  MEDIUM: 'Media',
+}
+
+export interface InventoryAlert {
+  kind: AlertKind
+  severity: AlertSeverity
+  message: string
+  link: string
+  metadata: Record<string, unknown>
+}
+
+// --- Umbrales -----------------------------------------------------------------
+export interface AlertThreshold {
+  id: number
+  resource_type_id: number
+  min_quantity: number
+  updated_by: number | null
+  updated_at: string
+  resource?: {
+    id: number
+    name: string
+    category: ResourceCategory
+    unit_of_measure: string
+    unit_weight_kg: number
+    is_active: boolean
+  }
+}
+
+export interface SetThresholdPayload {
+  resource_type_id: number
+  min_quantity: number
+}
+
+// --- Ajustes ------------------------------------------------------------------
+export type AdjustmentReason = 'MERMA' | 'DANO' | 'DEVOLUCION' | 'CORRECCION'
+
+export const ADJUSTMENT_REASON_OPTIONS: { value: AdjustmentReason; label: string }[] = [
+  { value: 'MERMA', label: 'Merma' },
+  { value: 'DANO', label: 'Daño' },
+  { value: 'DEVOLUCION', label: 'Devolución' },
+  { value: 'CORRECCION', label: 'Corrección de error' },
+]
+
+export interface UpsertInventoryPayload {
+  warehouse_id: number
+  resource_type_id: number
+  quantity: number
+  batch?: string | null
+  expiration_date?: string | null
+}
+
+export interface AdjustInventoryPayload {
+  delta: number
+  reason: AdjustmentReason
+  reason_note: string
+}

--- a/client/src/types/warehouse.types.ts
+++ b/client/src/types/warehouse.types.ts
@@ -1,0 +1,59 @@
+// Tipos del módulo de bodegas. Reflejan server/src/types/entities.ts y la API
+// /warehouses. La capacidad se mide en kg (RN-03, HU-11).
+
+export type WarehouseStatus = 'ACTIVE' | 'INACTIVE'
+
+export const WAREHOUSE_STATUS_OPTIONS: { value: WarehouseStatus; label: string }[] = [
+  { value: 'ACTIVE', label: 'Activa' },
+  { value: 'INACTIVE', label: 'Inactiva' },
+]
+
+export const WAREHOUSE_STATUS_LABELS = Object.fromEntries(
+  WAREHOUSE_STATUS_OPTIONS.map((o) => [o.value, o.label]),
+) as Record<WarehouseStatus, string>
+
+export interface Warehouse {
+  id: number
+  name: string
+  address: string
+  zone_id: number
+  max_capacity_kg: number
+  current_weight_kg: number
+  status: WarehouseStatus
+  latitude: number
+  longitude: number
+  created_at?: string
+  updated_at?: string
+}
+
+// GET /warehouses y /warehouses/:id agregan indicadores de ocupación:
+//  - is_over_85_percent: alerta al 85% (HU-11 CA3)
+//  - occupancy_ratio: peso / capacidad (0..1, null si capacidad 0)
+export interface WarehouseWithOccupancy extends Warehouse {
+  is_over_85_percent: boolean
+  occupancy_ratio: number | null
+}
+
+// GET /warehouses/nearest añade la distancia en km.
+export interface WarehouseWithDistance extends WarehouseWithOccupancy {
+  distance_km: number
+}
+
+export interface WarehouseListParams {
+  page: number
+  limit: number
+  zone_id?: number
+  status?: WarehouseStatus
+  search?: string
+}
+
+// Cuerpo de POST/PUT /warehouses (lat/lng obligatorias, RN-10 / HU-11 CA2).
+export interface WarehousePayload {
+  name: string
+  address: string
+  zone_id: number
+  max_capacity_kg: number
+  status?: WarehouseStatus
+  latitude: number
+  longitude: number
+}


### PR DESCRIPTION
## Paso 6 del frontend (Vue): Bodegas + Inventario

> **PR apilado** sobre #63 (auth) → #62 (familias). Base: `feature/fe-auth-users-hu01-03`. **Mergear en orden: #62 → #63 → este.** GitHub re-apunta a `dev` al mergear los anteriores.

Implementa el módulo de logística completo (6 páginas) con el patrón establecido del cliente (api + composable + types + schema Zod + UI kit + `RoleGate`).

### Páginas
- **WarehousesListPage** (`/warehouses`, HU-11): CRUD con **MapPicker obligatorio** (CA2); columna de **% de uso** con barra y **alerta al 85%** (`is_over_85_percent`, CA3); filtros zona/estado + paginación.
- **WarehouseDetailPage** (`/warehouses/:id`, HU-15/17): resumen de capacidad; tabla de inventario con **vencimientos resaltados** (rojo vencido, ámbar ≤30 días); **agregar stock** (upsert por lote) y **ajuste con motivo + nota** (MERMA/DAÑO/DEVOLUCIÓN/CORRECCIÓN); el backend **bloquea stock negativo** (409, HU-17 CA3).
- **ResourceTypesPage** (`/inventory/resource-types`, HU-14): catálogo CRUD, filtro por categoría, **soft-delete** (`is_active`) y reactivar (CA4).
- **InventorySummaryPage** (`/inventory/summary`, HU-15): KPIs + peso por categoría y por bodega.
- **InventoryAlertsPage** (`/inventory/alerts`): tarjetas por severidad (stock bajo, vencimientos, bodega >85%).
- **AlertThresholdsPage** (`/settings/alerts`, HU-16): tabla recurso + umbral con **edición inline** (PUT upsert).

### Soporte
- Tipos `warehouse.types.ts`, `inventory.types.ts`; esquemas `warehouse`/`resourceType`/`inventory`.
- API `warehouses`/`resourceTypes`/`inventory`; composables `useWarehouses`/`useResourceTypes`/`useInventory`.
- Rutas nuevas (con `meta.roles` en bodegas y umbrales); items de sidebar en **Logística** (Tipos de Recurso, Alertas) y **Configuración** (Umbrales).

### Notas de contrato (backend)
- `GET /warehouses` pagina con filtros `zone_id/status/search`. `GET /warehouses/:id/inventory` y `GET /inventory` devuelven filas enriquecidas (`resource` + `is_expired`).
- Ajustes: `delta` entero ≠ 0 + `reason` + `reason_note` (3–500). Upsert de stock: `quantity` entero > 0.
- `GET /resource-types` sin paginación; `DELETE` = soft-delete.
- `PUT /alert-thresholds` es upsert por `resource_type_id`.

### Verificación
- ✅ `pnpm -C client typecheck`
- ✅ `pnpm -C client build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)