### PR TITLE
feat(client): Donantes + Donaciones (Paso 7) — HU-18/19/20

### DIFF
--- a/client/src/api/donations.api.ts
+++ b/client/src/api/donations.api.ts
@@ -1,0 +1,24 @@
+import { api } from './axios'
+import type { ApiItem, ApiList } from '@/types/api.types'
+import type {
+  Donation, DonationEnriched, DonationListParams, DonationPayload,
+} from '@/types/donation.types'
+
+export const donationsApi = {
+  list(params: DonationListParams) {
+    const query: Record<string, string | number> = { page: params.page, limit: params.limit }
+    if (params.donor_id) query.donor_id = params.donor_id
+    if (params.type) query.type = params.type
+    if (params.date_from) query.date_from = params.date_from
+    if (params.date_to) query.date_to = params.date_to
+    return api.get<ApiList<DonationEnriched>>('/donations', { params: query }).then((r) => r.data)
+  },
+
+  getById(id: number) {
+    return api.get<ApiItem<DonationEnriched>>(`/donations/${id}`).then((r) => r.data.data)
+  },
+
+  create(payload: DonationPayload) {
+    return api.post<ApiItem<Donation>>('/donations', payload).then((r) => r.data.data)
+  },
+}

--- a/client/src/api/donors.api.ts
+++ b/client/src/api/donors.api.ts
@@ -1,0 +1,42 @@
+import { api } from './axios'
+import type { ApiItem, ApiList } from '@/types/api.types'
+import type { Donor, DonorListParams, DonorPayload } from '@/types/donor.types'
+import type { DonationEnriched } from '@/types/donation.types'
+
+export const donorsApi = {
+  // Catálogo completo para selects (formulario de donación).
+  listAll() {
+    return api
+      .get<ApiList<Donor>>('/donors', { params: { page: 1, limit: 200, is_active: true } })
+      .then((r) => r.data.data)
+  },
+
+  list(params: DonorListParams) {
+    const query: Record<string, string | number> = { page: params.page, limit: params.limit }
+    if (params.type) query.type = params.type
+    if (params.search) query.search = params.search
+    if (params.is_active !== undefined) query.is_active = String(params.is_active)
+    return api.get<ApiList<Donor>>('/donors', { params: query }).then((r) => r.data)
+  },
+
+  getById(id: number) {
+    return api.get<ApiItem<Donor>>(`/donors/${id}`).then((r) => r.data.data)
+  },
+
+  donations(id: number) {
+    return api.get<ApiItem<DonationEnriched[]>>(`/donors/${id}/donations`).then((r) => r.data.data)
+  },
+
+  create(payload: DonorPayload) {
+    return api.post<ApiItem<Donor>>('/donors', payload).then((r) => r.data.data)
+  },
+
+  update(id: number, payload: Partial<DonorPayload> & { is_active?: boolean }) {
+    return api.put<ApiItem<Donor>>(`/donors/${id}`, payload).then((r) => r.data.data)
+  },
+
+  // DELETE = soft delete (devuelve el donante actualizado, no 204).
+  deactivate(id: number) {
+    return api.delete<ApiItem<Donor>>(`/donors/${id}`).then((r) => r.data.data)
+  },
+}

--- a/client/src/components/layout/AppSidebar.vue
+++ b/client/src/components/layout/AppSidebar.vue
@@ -15,6 +15,8 @@ import {
   Boxes,
   Bell,
   Truck,
+  HeartHandshake,
+  Gift,
   Activity,
   BarChart3,
   Settings,
@@ -70,7 +72,8 @@ const groups: NavGroup[] = [
     title: 'Ayudas',
     items: [
       { label: 'Entregas', to: '/deliveries', icon: Truck },
-      { label: 'Donaciones', to: '/donations', icon: Package, roles: ['ADMIN', 'REGISTRADOR_DONACIONES'] },
+      { label: 'Donantes', to: '/donors', icon: HeartHandshake, roles: ['ADMIN', 'COORDINADOR_LOGISTICA', 'REGISTRADOR_DONACIONES', 'FUNCIONARIO_CONTROL'] },
+      { label: 'Donaciones', to: '/donations', icon: Gift, roles: ['ADMIN', 'COORDINADOR_LOGISTICA', 'REGISTRADOR_DONACIONES', 'FUNCIONARIO_CONTROL'] },
     ],
   },
   {

--- a/client/src/composables/useDonations.ts
+++ b/client/src/composables/useDonations.ts
@@ -1,0 +1,28 @@
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/vue-query'
+import type { Ref } from 'vue'
+import { donationsApi } from '@/api/donations.api'
+import type { DonationListParams } from '@/types/donation.types'
+
+export function useDonationsList(params: Ref<DonationListParams>) {
+  return useQuery({
+    queryKey: ['donations', 'list', params],
+    queryFn: () => donationsApi.list(params.value),
+    placeholderData: keepPreviousData,
+  })
+}
+
+// Crear donación. Una donación IN_KIND/MIXED actualiza el inventario de la bodega
+// destino → invalida también bodegas/inventario; y los totales del donante.
+export function useDonationMutations() {
+  const qc = useQueryClient()
+  const create = useMutation({
+    mutationFn: donationsApi.create,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['donations'] })
+      qc.invalidateQueries({ queryKey: ['donors'] })
+      qc.invalidateQueries({ queryKey: ['warehouses'] })
+      qc.invalidateQueries({ queryKey: ['inventory'] })
+    },
+  })
+  return { create }
+}

--- a/client/src/composables/useDonors.ts
+++ b/client/src/composables/useDonors.ts
@@ -1,0 +1,55 @@
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/vue-query'
+import { computed, type Ref } from 'vue'
+import { donorsApi } from '@/api/donors.api'
+import type { DonorListParams, DonorPayload } from '@/types/donor.types'
+
+// Catálogo de donantes activos para selects (formulario de donación).
+export function useDonors() {
+  return useQuery({
+    queryKey: ['donors', 'all'],
+    queryFn: donorsApi.listAll,
+    staleTime: 1000 * 60 * 5,
+  })
+}
+
+export function useDonorsList(params: Ref<DonorListParams>) {
+  return useQuery({
+    queryKey: ['donors', 'list', params],
+    queryFn: () => donorsApi.list(params.value),
+    placeholderData: keepPreviousData,
+  })
+}
+
+export function useDonor(id: Ref<number>) {
+  return useQuery({
+    queryKey: ['donors', 'detail', id],
+    queryFn: () => donorsApi.getById(id.value),
+    enabled: computed(() => id.value > 0),
+  })
+}
+
+export function useDonorDonations(id: Ref<number>) {
+  return useQuery({
+    queryKey: ['donors', 'donations', id],
+    queryFn: () => donorsApi.donations(id.value),
+    enabled: computed(() => id.value > 0),
+  })
+}
+
+export function useDonorMutations() {
+  const qc = useQueryClient()
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: ['donors'] })
+    qc.invalidateQueries({ queryKey: ['donations'] })
+  }
+
+  const create = useMutation({ mutationFn: donorsApi.create, onSuccess: invalidate })
+  const update = useMutation({
+    mutationFn: ({ id, payload }: { id: number; payload: Partial<DonorPayload> & { is_active?: boolean } }) =>
+      donorsApi.update(id, payload),
+    onSuccess: invalidate,
+  })
+  const deactivate = useMutation({ mutationFn: donorsApi.deactivate, onSuccess: invalidate })
+
+  return { create, update, deactivate }
+}

--- a/client/src/pages/donations/DonationFormPage.vue
+++ b/client/src/pages/donations/DonationFormPage.vue
@@ -1,0 +1,245 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { toast } from 'vue-sonner'
+import { ArrowLeft, Plus, Trash2, Save, TriangleAlert } from '@lucide/vue'
+import { useDonors } from '@/composables/useDonors'
+import { useWarehouses } from '@/composables/useWarehouses'
+import { useResourceTypes } from '@/composables/useResourceTypes'
+import { useDonationMutations } from '@/composables/useDonations'
+import { DONATION_TYPE_OPTIONS } from '@/types/donation.types'
+import type { DonationDetailInput, DonationPayload, DonationType } from '@/types/donation.types'
+import type { ResourceTypeListParams } from '@/types/inventory.types'
+import { apiErrorMessage } from '@/utils/apiError'
+import PageHeader from '@/components/ui/PageHeader.vue'
+import AppButton from '@/components/ui/AppButton.vue'
+import FormField from '@/components/form/FormField.vue'
+import SelectField from '@/components/form/SelectField.vue'
+
+const route = useRoute()
+const router = useRouter()
+
+const { data: donors } = useDonors()
+const { data: warehouses } = useWarehouses()
+const activeResourceParams = ref<ResourceTypeListParams>({ is_active: true })
+const { data: resourceTypes } = useResourceTypes(activeResourceParams)
+const { create } = useDonationMutations()
+const saving = computed(() => create.isPending.value)
+
+const todayStr = new Date().toISOString().slice(0, 10)
+const form = ref({
+  donor_id: (route.query.donor_id as string) || '',
+  donation_type: 'IN_KIND' as DonationType,
+  date: todayStr,
+  notes: '',
+  monetary_amount: '',
+  destination_warehouse_id: '',
+})
+interface ItemRow {
+  resource_type_id: string
+  quantity: string
+  batch: string
+  expiration_date: string
+}
+const items = ref<ItemRow[]>([{ resource_type_id: '', quantity: '', batch: '', expiration_date: '' }])
+const errors = ref<Record<string, string>>({})
+
+const needsItems = computed(() => form.value.donation_type === 'IN_KIND' || form.value.donation_type === 'MIXED')
+const needsMoney = computed(() => form.value.donation_type === 'MONETARY' || form.value.donation_type === 'MIXED')
+
+const donorOptions = computed(() => [
+  { value: '', label: 'Selecciona el donante…' },
+  ...(donors.value ?? []).map((d) => ({ value: String(d.id), label: d.name })),
+])
+const warehouseOptions = computed(() => [
+  { value: '', label: 'Selecciona la bodega…' },
+  ...(warehouses.value ?? []).map((w) => ({ value: String(w.id), label: w.name })),
+])
+const resourceOptions = computed(() => [
+  { value: '', label: 'Recurso…' },
+  ...(resourceTypes.value ?? []).map((rt) => ({ value: String(rt.id), label: `${rt.name} (${rt.unit_of_measure})` })),
+])
+
+const resourceMap = computed(() => new Map((resourceTypes.value ?? []).map((rt) => [rt.id, rt])))
+function itemWeight(it: ItemRow) {
+  const rt = resourceMap.value.get(Number(it.resource_type_id))
+  const q = Number(it.quantity)
+  return rt && q > 0 ? rt.unit_weight_kg * q : 0
+}
+const totalWeight = computed(() => items.value.reduce((a, it) => a + itemWeight(it), 0))
+
+const selectedWarehouse = computed(() =>
+  form.value.destination_warehouse_id
+    ? (warehouses.value ?? []).find((w) => w.id === Number(form.value.destination_warehouse_id))
+    : undefined,
+)
+const remainingCapacity = computed(() =>
+  selectedWarehouse.value ? selectedWarehouse.value.max_capacity_kg - selectedWarehouse.value.current_weight_kg : null,
+)
+// HU-19 CA3: alerta si el peso estimado excede la capacidad disponible.
+const exceedsCapacity = computed(
+  () => needsItems.value && remainingCapacity.value != null && totalWeight.value > remainingCapacity.value,
+)
+
+const kg = (n: number) => `${Math.round(n).toLocaleString('es-CO')} kg`
+
+function addItem() {
+  items.value.push({ resource_type_id: '', quantity: '', batch: '', expiration_date: '' })
+}
+function removeItem(i: number) {
+  items.value.splice(i, 1)
+}
+
+function validateForm() {
+  const e: Record<string, string> = {}
+  if (!form.value.donor_id) e.donor_id = 'Selecciona el donante.'
+  if (!form.value.date) e.date = 'Ingresa la fecha.'
+  if (needsMoney.value) {
+    const n = Number(form.value.monetary_amount)
+    if (!form.value.monetary_amount || Number.isNaN(n) || n <= 0) e.monetary_amount = 'Ingresa un monto mayor que 0.'
+  }
+  if (needsItems.value) {
+    if (!form.value.destination_warehouse_id) e.destination_warehouse_id = 'Selecciona la bodega destino.'
+    if (!items.value.length) {
+      e.details = 'Agrega al menos un ítem.'
+    } else {
+      const bad = items.value.some(
+        (it) => !it.resource_type_id || !it.quantity || Number(it.quantity) <= 0 || !Number.isInteger(Number(it.quantity)),
+      )
+      if (bad) e.details = 'Cada ítem requiere un recurso y una cantidad entera mayor que 0.'
+    }
+  }
+  errors.value = e
+  return Object.keys(e).length === 0
+}
+
+async function submit() {
+  if (!validateForm()) return
+  const payload: DonationPayload = {
+    donor_id: Number(form.value.donor_id),
+    donation_type: form.value.donation_type,
+    date: form.value.date,
+    notes: form.value.notes.trim() || null,
+  }
+  if (needsMoney.value) payload.monetary_amount = String(Number(form.value.monetary_amount))
+  if (needsItems.value) {
+    payload.destination_warehouse_id = Number(form.value.destination_warehouse_id)
+    payload.details = items.value.map<DonationDetailInput>((it) => ({
+      resource_type_id: Number(it.resource_type_id),
+      quantity: Number(it.quantity),
+      batch: it.batch.trim() || null,
+      expiration_date: it.expiration_date || null,
+    }))
+  }
+  try {
+    const created = await create.mutateAsync(payload)
+    toast.success(`Donación ${created.donation_code} registrada`)
+    router.push('/donations')
+  } catch (e) {
+    toast.error(apiErrorMessage(e, 'No se pudo registrar. Verifica la capacidad de la bodega destino.'))
+  }
+}
+</script>
+
+<template>
+  <section class="mx-auto max-w-3xl space-y-5">
+    <PageHeader title="Registrar donación" crumb="Ayudas" subtitle="Donación en especie, monetaria o mixta">
+      <template #actions>
+        <AppButton variant="outline" @click="router.push('/donations')"><ArrowLeft /> Volver</AppButton>
+      </template>
+    </PageHeader>
+
+    <form class="space-y-5" @submit.prevent="submit">
+      <!-- Datos generales -->
+      <fieldset class="space-y-4 rounded-lg border border-neutral-200 bg-white p-5">
+        <legend class="px-1 text-sm font-semibold text-neutral-700">Datos generales</legend>
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <SelectField v-model="form.donor_id" label="Donante" required :options="donorOptions" :error="errors.donor_id" input-id="dn-donor" />
+          <SelectField
+            v-model="form.donation_type"
+            label="Tipo de donación"
+            required
+            :options="DONATION_TYPE_OPTIONS.map((o) => ({ value: o.value as string, label: o.label }))"
+            input-id="dn-type"
+          />
+        </div>
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <FormField label="Fecha" required :error="errors.date" input-id="dn-date">
+            <input id="dn-date" v-model="form.date" type="date" :max="todayStr" class="control" />
+          </FormField>
+          <FormField label="Notas" :error="errors.notes" input-id="dn-notes" hint="Opcional">
+            <input id="dn-notes" v-model="form.notes" class="control" placeholder="Observaciones…" />
+          </FormField>
+        </div>
+      </fieldset>
+
+      <!-- Monto monetario -->
+      <fieldset v-if="needsMoney" class="space-y-4 rounded-lg border border-neutral-200 bg-white p-5">
+        <legend class="px-1 text-sm font-semibold text-neutral-700">Aporte monetario</legend>
+        <FormField label="Monto (COP)" required :error="errors.monetary_amount" input-id="dn-amount">
+          <input id="dn-amount" v-model="form.monetary_amount" type="number" min="1" step="any" class="control" placeholder="0" />
+        </FormField>
+      </fieldset>
+
+      <!-- Ítems en especie -->
+      <fieldset v-if="needsItems" class="space-y-4 rounded-lg border border-neutral-200 bg-white p-5">
+        <legend class="px-1 text-sm font-semibold text-neutral-700">Donación en especie</legend>
+
+        <SelectField
+          v-model="form.destination_warehouse_id"
+          label="Bodega destino"
+          required
+          :options="warehouseOptions"
+          :error="errors.destination_warehouse_id"
+          input-id="dn-wh"
+        />
+
+        <div class="space-y-3">
+          <div
+            v-for="(it, i) in items"
+            :key="i"
+            class="grid grid-cols-1 gap-3 rounded-md border border-neutral-200 p-3 sm:grid-cols-[2fr_1fr_1fr_auto]"
+          >
+            <SelectField v-model="it.resource_type_id" :options="resourceOptions" />
+            <FormField label="" input-id="">
+              <input v-model="it.quantity" type="number" min="1" class="control" placeholder="Cantidad" />
+            </FormField>
+            <FormField label="" input-id="">
+              <input v-model="it.batch" class="control" placeholder="Lote (opc.)" />
+            </FormField>
+            <div class="flex items-center justify-between gap-2 sm:flex-col sm:items-end sm:justify-center">
+              <span class="font-mono text-xs text-neutral-500">{{ kg(itemWeight(it)) }}</span>
+              <AppButton type="button" variant="ghost" size="sm" class="text-danger" :disabled="items.length === 1" @click="removeItem(i)">
+                <Trash2 />
+              </AppButton>
+            </div>
+            <FormField label="" input-id="" class="sm:col-span-4">
+              <input v-model="it.expiration_date" type="date" class="control" placeholder="Vence (opc.)" />
+            </FormField>
+          </div>
+
+          <p v-if="errors.details" class="text-sm text-danger">{{ errors.details }}</p>
+          <AppButton type="button" variant="outline" size="sm" @click="addItem"><Plus /> Agregar ítem</AppButton>
+        </div>
+
+        <!-- Peso total + alerta de capacidad -->
+        <div class="flex items-center justify-between rounded-md bg-neutral-50 p-3 text-sm">
+          <span class="text-neutral-600">Peso estimado total</span>
+          <span class="font-mono font-semibold text-neutral-900">{{ kg(totalWeight) }}</span>
+        </div>
+        <div v-if="selectedWarehouse" class="text-xs text-neutral-500">
+          Capacidad disponible en {{ selectedWarehouse.name }}: {{ kg(remainingCapacity ?? 0) }}
+        </div>
+        <div v-if="exceedsCapacity" class="flex items-start gap-2 rounded-md border border-warning-br bg-warning-bg p-3 text-sm text-warning">
+          <TriangleAlert class="mt-0.5 h-4 w-4 flex-none" />
+          <span>El peso estimado supera la capacidad disponible de la bodega destino (HU-19). El registro podría ser rechazado.</span>
+        </div>
+      </fieldset>
+
+      <div class="flex items-center justify-end gap-3 pb-4">
+        <AppButton variant="ghost" type="button" @click="router.push('/donations')">Cancelar</AppButton>
+        <AppButton type="submit" :disabled="saving"><Save /> {{ saving ? 'Registrando…' : 'Registrar donación' }}</AppButton>
+      </div>
+    </form>
+  </section>
+</template>

--- a/client/src/pages/donations/DonationsListPage.vue
+++ b/client/src/pages/donations/DonationsListPage.vue
@@ -1,0 +1,202 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import { Plus, Eye, SearchX, RotateCcw, ChevronLeft, ChevronRight } from '@lucide/vue'
+import { useDonationsList } from '@/composables/useDonations'
+import { useDonors } from '@/composables/useDonors'
+import { DONATION_TYPE_OPTIONS, DONATION_TYPE_LABELS } from '@/types/donation.types'
+import type { DonationEnriched, DonationListParams, DonationType } from '@/types/donation.types'
+import { RESOURCE_CATEGORY_LABELS } from '@/types/inventory.types'
+import PageHeader from '@/components/ui/PageHeader.vue'
+import AppButton from '@/components/ui/AppButton.vue'
+import DataTable from '@/components/ui/DataTable.vue'
+import EmptyState from '@/components/ui/EmptyState.vue'
+import SkeletonBlock from '@/components/ui/SkeletonBlock.vue'
+import BaseModal from '@/components/ui/BaseModal.vue'
+import SelectField from '@/components/form/SelectField.vue'
+import FormField from '@/components/form/FormField.vue'
+import RoleGate from '@/components/auth/RoleGate.vue'
+
+const router = useRouter()
+const PAGE_SIZE = 20
+const EDIT_ROLES = ['ADMIN', 'COORDINADOR_LOGISTICA', 'REGISTRADOR_DONACIONES'] as const
+
+const donorFilter = ref('')
+const typeFilter = ref('')
+const dateFrom = ref('')
+const dateTo = ref('')
+const page = ref(1)
+
+watch([donorFilter, typeFilter, dateFrom, dateTo], () => {
+  page.value = 1
+})
+
+const params = computed<DonationListParams>(() => ({
+  page: page.value,
+  limit: PAGE_SIZE,
+  ...(donorFilter.value ? { donor_id: Number(donorFilter.value) } : {}),
+  ...(typeFilter.value ? { type: typeFilter.value as DonationType } : {}),
+  ...(dateFrom.value ? { date_from: dateFrom.value } : {}),
+  ...(dateTo.value ? { date_to: dateTo.value } : {}),
+}))
+
+const { data, isLoading, isFetching, isError, refetch } = useDonationsList(params)
+const { data: donors } = useDonors()
+
+const donorMap = computed(() => new Map((donors.value ?? []).map((d) => [d.id, d])))
+const rows = computed(() => data.value?.data ?? [])
+const total = computed(() => data.value?.pagination.total ?? 0)
+const totalPages = computed(() => data.value?.pagination.totalPages ?? 1)
+const rangeFrom = computed(() => (total.value === 0 ? 0 : (page.value - 1) * PAGE_SIZE + 1))
+const rangeTo = computed(() => Math.min(page.value * PAGE_SIZE, total.value))
+const hasFilters = computed(() => !!(donorFilter.value || typeFilter.value || dateFrom.value || dateTo.value))
+
+const donorOptions = computed(() => [
+  { value: '', label: 'Todos los donantes' },
+  ...(donors.value ?? []).map((d) => ({ value: String(d.id), label: d.name })),
+])
+const typeFilterOptions = [{ value: '', label: 'Todos los tipos' }, ...DONATION_TYPE_OPTIONS]
+
+const columns = [
+  { key: 'donation_code', label: 'Código', mono: true },
+  { key: 'donor', label: 'Donante' },
+  { key: 'donation_type', label: 'Tipo' },
+  { key: 'date', label: 'Fecha' },
+  { key: 'amount', label: 'Monto', align: 'right' as const },
+  { key: 'items', label: 'Ítems', align: 'center' as const },
+  { key: 'actions', label: '', align: 'right' as const },
+]
+const asDonation = (r: unknown) => r as DonationEnriched
+
+function donorName(d: DonationEnriched) {
+  return d.donor?.name ?? donorMap.value.get(d.donor_id)?.name ?? `#${d.donor_id}`
+}
+function fmtDate(s: string) {
+  return new Date(s).toLocaleDateString('es-CO', { day: '2-digit', month: 'short', year: 'numeric' })
+}
+function fmtMoney(v: string | null) {
+  if (!v) return '—'
+  return Number(v).toLocaleString('es-CO', { style: 'currency', currency: 'COP', maximumFractionDigits: 0 })
+}
+function goTo(p: number) {
+  page.value = Math.min(Math.max(1, p), totalPages.value)
+}
+function clearFilters() {
+  donorFilter.value = ''
+  typeFilter.value = ''
+  dateFrom.value = ''
+  dateTo.value = ''
+}
+
+// --- Modal de detalle ---------------------------------------------------------
+const detailOpen = ref(false)
+const detail = ref<DonationEnriched | null>(null)
+function openDetail(d: DonationEnriched) {
+  detail.value = d
+  detailOpen.value = true
+}
+</script>
+
+<template>
+  <section class="space-y-5">
+    <PageHeader
+      title="Donaciones"
+      crumb="Ayudas"
+      :subtitle="total ? `${total} ${total === 1 ? 'donación' : 'donaciones'}` : 'Registro de donaciones recibidas'"
+    >
+      <template #actions>
+        <RoleGate :roles="[...EDIT_ROLES]">
+          <AppButton @click="router.push('/donations/new')"><Plus /> Registrar donación</AppButton>
+        </RoleGate>
+      </template>
+    </PageHeader>
+
+    <div class="grid grid-cols-1 gap-3 rounded-lg border border-neutral-200 bg-white p-4 sm:grid-cols-2 lg:grid-cols-4">
+      <SelectField v-model="donorFilter" :options="donorOptions" />
+      <SelectField v-model="typeFilter" :options="typeFilterOptions" />
+      <FormField label="" input-id="d-from"><input id="d-from" v-model="dateFrom" type="date" class="control" /></FormField>
+      <FormField label="" input-id="d-to"><input id="d-to" v-model="dateTo" type="date" class="control" /></FormField>
+    </div>
+
+    <div v-if="isError" class="rounded-lg border border-danger-br bg-danger-bg p-6 text-center">
+      <p class="text-sm text-danger">No se pudieron cargar las donaciones.</p>
+      <AppButton variant="outline" size="sm" class="mt-3" @click="() => refetch()"><RotateCcw /> Reintentar</AppButton>
+    </div>
+
+    <div v-else-if="isLoading" class="space-y-2 rounded-lg border border-neutral-200 bg-white p-4">
+      <SkeletonBlock v-for="n in 6" :key="n" height="44px" />
+    </div>
+
+    <template v-else>
+      <div :class="{ 'opacity-60 transition-opacity': isFetching }">
+        <DataTable :columns="columns" :rows="rows" row-key="id" min-width="900px">
+          <template #donation_code="{ row }"><span class="font-semibold text-neutral-900">{{ asDonation(row).donation_code }}</span></template>
+          <template #donor="{ row }">{{ donorName(asDonation(row)) }}</template>
+          <template #donation_type="{ row }">
+            <span class="rounded-full bg-info-bg px-2.5 py-1 text-xs font-medium text-primary-700">
+              {{ DONATION_TYPE_LABELS[asDonation(row).donation_type] }}
+            </span>
+          </template>
+          <template #date="{ row }">{{ fmtDate(asDonation(row).date) }}</template>
+          <template #amount="{ row }"><span class="font-mono text-xs">{{ fmtMoney(asDonation(row).monetary_amount) }}</span></template>
+          <template #items="{ row }">{{ asDonation(row).details?.length ?? 0 }}</template>
+          <template #actions="{ row }">
+            <AppButton variant="ghost" size="sm" @click="openDetail(asDonation(row))"><Eye /> Ver</AppButton>
+          </template>
+          <template #empty>
+            <EmptyState
+              title="Sin donaciones"
+              :message="hasFilters ? 'No hay donaciones que coincidan con los filtros.' : 'Aún no se han registrado donaciones.'"
+            >
+              <template #icon><SearchX /></template>
+              <template #action>
+                <AppButton v-if="hasFilters" variant="outline" size="sm" @click="clearFilters"><RotateCcw /> Limpiar filtros</AppButton>
+                <RoleGate v-else :roles="[...EDIT_ROLES]">
+                  <AppButton size="sm" @click="router.push('/donations/new')"><Plus /> Registrar donación</AppButton>
+                </RoleGate>
+              </template>
+            </EmptyState>
+          </template>
+        </DataTable>
+      </div>
+
+      <div v-if="total > 0" class="flex flex-wrap items-center justify-between gap-3 text-sm text-neutral-600">
+        <span>Mostrando <strong>{{ rangeFrom }}–{{ rangeTo }}</strong> de <strong>{{ total }}</strong></span>
+        <div class="flex items-center gap-2">
+          <AppButton variant="outline" size="sm" :disabled="page <= 1" @click="goTo(page - 1)"><ChevronLeft /></AppButton>
+          <span class="px-1">Página {{ page }} de {{ totalPages }}</span>
+          <AppButton variant="outline" size="sm" :disabled="page >= totalPages" @click="goTo(page + 1)"><ChevronRight /></AppButton>
+        </div>
+      </div>
+    </template>
+
+    <!-- Modal de detalle -->
+    <BaseModal :open="detailOpen" :title="detail ? `Donación ${detail.donation_code}` : ''" max-width="max-w-[600px]" @close="detailOpen = false">
+      <div v-if="detail" class="space-y-4">
+        <dl class="grid grid-cols-2 gap-3 text-sm">
+          <div><dt class="text-neutral-500">Donante</dt><dd class="font-medium text-neutral-900">{{ donorName(detail) }}</dd></div>
+          <div><dt class="text-neutral-500">Tipo</dt><dd class="font-medium text-neutral-900">{{ DONATION_TYPE_LABELS[detail.donation_type] }}</dd></div>
+          <div><dt class="text-neutral-500">Fecha</dt><dd class="font-medium text-neutral-900">{{ fmtDate(detail.date) }}</dd></div>
+          <div><dt class="text-neutral-500">Monto</dt><dd class="font-medium text-neutral-900">{{ fmtMoney(detail.monetary_amount) }}</dd></div>
+        </dl>
+        <p v-if="detail.notes" class="rounded-md bg-neutral-50 p-3 text-sm text-neutral-600">{{ detail.notes }}</p>
+
+        <div v-if="detail.details?.length">
+          <h3 class="mb-2 text-sm font-semibold text-neutral-700">Ítems en especie</h3>
+          <ul class="divide-y divide-neutral-100 rounded-md border border-neutral-200">
+            <li v-for="it in detail.details" :key="it.id" class="flex items-center justify-between px-3 py-2 text-sm">
+              <span>
+                <span class="font-medium text-neutral-900">{{ it.resource_name }}</span>
+                <span class="ml-1 text-xs text-neutral-500">({{ RESOURCE_CATEGORY_LABELS[it.category] }})</span>
+              </span>
+              <span class="font-mono text-xs text-neutral-700">{{ it.quantity }} u · {{ Math.round(it.weight_kg).toLocaleString('es-CO') }} kg</span>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <template #footer>
+        <AppButton @click="detailOpen = false">Cerrar</AppButton>
+      </template>
+    </BaseModal>
+  </section>
+</template>

--- a/client/src/pages/donors/DonorDetailPage.vue
+++ b/client/src/pages/donors/DonorDetailPage.vue
@@ -1,0 +1,130 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { ArrowLeft, Plus, Gift, RotateCcw } from '@lucide/vue'
+import { useDonor, useDonorDonations } from '@/composables/useDonors'
+import { DONOR_TYPE_LABELS } from '@/types/donor.types'
+import { DONATION_TYPE_LABELS } from '@/types/donation.types'
+import type { DonationEnriched } from '@/types/donation.types'
+import PageHeader from '@/components/ui/PageHeader.vue'
+import AppButton from '@/components/ui/AppButton.vue'
+import DataTable from '@/components/ui/DataTable.vue'
+import EmptyState from '@/components/ui/EmptyState.vue'
+import SkeletonBlock from '@/components/ui/SkeletonBlock.vue'
+import RoleGate from '@/components/auth/RoleGate.vue'
+
+const route = useRoute()
+const router = useRouter()
+const donorId = computed(() => Number(route.params.id))
+const EDIT_ROLES = ['ADMIN', 'COORDINADOR_LOGISTICA', 'REGISTRADOR_DONACIONES'] as const
+
+const { data: donor, isLoading, isError, refetch } = useDonor(donorId)
+const { data: donations, isLoading: loadingDonations } = useDonorDonations(donorId)
+
+const asDonation = (r: unknown) => r as DonationEnriched
+
+const columns = [
+  { key: 'donation_code', label: 'Código', mono: true },
+  { key: 'donation_type', label: 'Tipo' },
+  { key: 'date', label: 'Fecha' },
+  { key: 'amount', label: 'Monto', align: 'right' as const },
+  { key: 'weight', label: 'Peso', align: 'right' as const },
+  { key: 'items', label: 'Ítems', align: 'center' as const },
+]
+
+function fmtDate(s: string) {
+  return new Date(s).toLocaleDateString('es-CO', { day: '2-digit', month: 'short', year: 'numeric' })
+}
+function fmtMoney(v: string | null) {
+  if (!v) return '—'
+  return Number(v).toLocaleString('es-CO', { style: 'currency', currency: 'COP', maximumFractionDigits: 0 })
+}
+function donationWeight(d: DonationEnriched) {
+  if (!d.details?.length) return '—'
+  const w = d.details.reduce((a, it) => a + (it.weight_kg ?? 0), 0)
+  return `${Math.round(w).toLocaleString('es-CO')} kg`
+}
+
+const totalMoney = computed(() =>
+  (donations.value ?? []).reduce((a, d) => a + Number(d.monetary_amount ?? 0), 0),
+)
+</script>
+
+<template>
+  <section class="space-y-5">
+    <div v-if="isLoading" class="space-y-4">
+      <SkeletonBlock height="120px" />
+      <SkeletonBlock height="180px" />
+    </div>
+    <div v-else-if="isError || !donor" class="rounded-lg border border-danger-br bg-danger-bg p-6 text-center">
+      <p class="text-sm text-danger">No se pudo cargar el donante.</p>
+      <AppButton variant="outline" size="sm" class="mt-3" @click="() => refetch()"><RotateCcw /> Reintentar</AppButton>
+    </div>
+
+    <template v-else>
+      <PageHeader :title="donor.name" :crumb="`Donantes · ${DONOR_TYPE_LABELS[donor.type]}`">
+        <template #actions>
+          <AppButton variant="outline" @click="router.push('/donors')"><ArrowLeft /> Volver</AppButton>
+          <RoleGate :roles="[...EDIT_ROLES]">
+            <AppButton @click="router.push(`/donations/new?donor_id=${donorId}`)"><Plus /> Nueva donación</AppButton>
+          </RoleGate>
+        </template>
+      </PageHeader>
+
+      <div class="rounded-lg border border-neutral-200 bg-white p-5">
+        <dl class="grid grid-cols-1 gap-4 text-sm sm:grid-cols-3">
+          <div>
+            <dt class="text-neutral-500">Tipo</dt>
+            <dd class="font-medium text-neutral-900">{{ DONOR_TYPE_LABELS[donor.type] }}</dd>
+          </div>
+          <div>
+            <dt class="text-neutral-500">Contacto</dt>
+            <dd class="font-medium text-neutral-900">{{ donor.contact }}</dd>
+          </div>
+          <div>
+            <dt class="text-neutral-500">NIT / Documento</dt>
+            <dd class="font-medium text-neutral-900">{{ donor.tax_id || '—' }}</dd>
+          </div>
+          <div>
+            <dt class="text-neutral-500">Estado</dt>
+            <dd class="font-medium" :class="donor.is_active ? 'text-success' : 'text-neutral-500'">
+              {{ donor.is_active ? 'Activo' : 'Inactivo' }}
+            </dd>
+          </div>
+          <div>
+            <dt class="text-neutral-500">Donaciones</dt>
+            <dd class="font-medium text-neutral-900">{{ donations?.length ?? 0 }}</dd>
+          </div>
+          <div>
+            <dt class="text-neutral-500">Total monetario</dt>
+            <dd class="font-medium text-neutral-900">
+              {{ totalMoney.toLocaleString('es-CO', { style: 'currency', currency: 'COP', maximumFractionDigits: 0 }) }}
+            </dd>
+          </div>
+        </dl>
+      </div>
+
+      <h2 class="text-sm font-semibold text-neutral-700">Historial de donaciones</h2>
+      <div v-if="loadingDonations" class="space-y-2 rounded-lg border border-neutral-200 bg-white p-4">
+        <SkeletonBlock v-for="n in 3" :key="n" height="40px" />
+      </div>
+      <DataTable v-else :columns="columns" :rows="donations ?? []" row-key="id" min-width="720px">
+        <template #donation_type="{ row }">{{ DONATION_TYPE_LABELS[asDonation(row).donation_type] }}</template>
+        <template #date="{ row }">{{ fmtDate(asDonation(row).date) }}</template>
+        <template #amount="{ row }"><span class="font-mono text-xs">{{ fmtMoney(asDonation(row).monetary_amount) }}</span></template>
+        <template #weight="{ row }"><span class="font-mono text-xs">{{ donationWeight(asDonation(row)) }}</span></template>
+        <template #items="{ row }">{{ asDonation(row).details?.length ?? 0 }}</template>
+        <template #empty>
+          <EmptyState title="Sin donaciones" message="Este donante aún no tiene donaciones registradas.">
+            <template #icon><Gift /></template>
+            <template #action>
+              <RoleGate :roles="[...EDIT_ROLES]">
+                <AppButton size="sm" @click="router.push(`/donations/new?donor_id=${donorId}`)"><Plus /> Nueva donación</AppButton>
+              </RoleGate>
+            </template>
+          </EmptyState>
+        </template>
+      </DataTable>
+    </template>
+  </section>
+</template>

--- a/client/src/pages/donors/DonorsListPage.vue
+++ b/client/src/pages/donors/DonorsListPage.vue
@@ -1,0 +1,269 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { toast } from 'vue-sonner'
+import { Plus, Pencil, Ban, Eye, SearchX, RotateCcw, ChevronLeft, ChevronRight } from '@lucide/vue'
+import { useDonorsList, useDonorMutations } from '@/composables/useDonors'
+import { DONOR_TYPE_OPTIONS, DONOR_TYPE_LABELS } from '@/types/donor.types'
+import type { Donor, DonorListParams, DonorPayload, DonorType } from '@/types/donor.types'
+import { donorSchema } from '@/schemas/donor.schema'
+import { validate } from '@/utils/validation'
+import { apiErrorMessage } from '@/utils/apiError'
+import PageHeader from '@/components/ui/PageHeader.vue'
+import AppButton from '@/components/ui/AppButton.vue'
+import DataTable from '@/components/ui/DataTable.vue'
+import EmptyState from '@/components/ui/EmptyState.vue'
+import SkeletonBlock from '@/components/ui/SkeletonBlock.vue'
+import BaseModal from '@/components/ui/BaseModal.vue'
+import ConfirmDialog from '@/components/ui/ConfirmDialog.vue'
+import SearchInput from '@/components/form/SearchInput.vue'
+import SelectField from '@/components/form/SelectField.vue'
+import FormField from '@/components/form/FormField.vue'
+import RoleGate from '@/components/auth/RoleGate.vue'
+
+const router = useRouter()
+const PAGE_SIZE = 20
+const EDIT_ROLES = ['ADMIN', 'COORDINADOR_LOGISTICA', 'REGISTRADOR_DONACIONES'] as const
+const DELETE_ROLES = ['ADMIN', 'COORDINADOR_LOGISTICA'] as const
+
+const search = ref('')
+const typeFilter = ref('')
+const statusFilter = ref('')
+const page = ref(1)
+
+const params = computed<DonorListParams>(() => ({
+  page: page.value,
+  limit: PAGE_SIZE,
+  ...(search.value ? { search: search.value } : {}),
+  ...(typeFilter.value ? { type: typeFilter.value as DonorType } : {}),
+  ...(statusFilter.value ? { is_active: statusFilter.value === 'true' } : {}),
+}))
+
+const { data, isLoading, isFetching, isError, refetch } = useDonorsList(params)
+const rows = computed(() => data.value?.data ?? [])
+const total = computed(() => data.value?.pagination.total ?? 0)
+const totalPages = computed(() => data.value?.pagination.totalPages ?? 1)
+const rangeFrom = computed(() => (total.value === 0 ? 0 : (page.value - 1) * PAGE_SIZE + 1))
+const rangeTo = computed(() => Math.min(page.value * PAGE_SIZE, total.value))
+const hasFilters = computed(() => !!(search.value || typeFilter.value || statusFilter.value))
+
+const typeFilterOptions = [{ value: '', label: 'Todos los tipos' }, ...DONOR_TYPE_OPTIONS]
+const typeFormOptions = [{ value: '', label: 'Selecciona el tipo…' }, ...DONOR_TYPE_OPTIONS]
+const statusFilterOptions = [
+  { value: '', label: 'Todos' },
+  { value: 'true', label: 'Activos' },
+  { value: 'false', label: 'Inactivos' },
+]
+
+const columns = [
+  { key: 'name', label: 'Donante' },
+  { key: 'type', label: 'Tipo' },
+  { key: 'contact', label: 'Contacto' },
+  { key: 'status', label: 'Estado', align: 'center' as const },
+  { key: 'actions', label: '', align: 'right' as const },
+]
+const asDonor = (r: unknown) => r as Donor
+function goTo(p: number) {
+  page.value = Math.min(Math.max(1, p), totalPages.value)
+}
+function clearFilters() {
+  search.value = ''
+  typeFilter.value = ''
+  statusFilter.value = ''
+}
+
+// --- Modal crear / editar -----------------------------------------------------
+const { create, update, deactivate } = useDonorMutations()
+const saving = computed(() => create.isPending.value || update.isPending.value)
+const modalOpen = ref(false)
+const editId = ref<number | null>(null)
+const errors = ref<Record<string, string>>({})
+function blankForm() {
+  return { name: '', type: '', contact: '', tax_id: '' }
+}
+const form = ref(blankForm())
+
+function openCreate() {
+  editId.value = null
+  form.value = blankForm()
+  errors.value = {}
+  modalOpen.value = true
+}
+function openEdit(d: Donor) {
+  editId.value = d.id
+  form.value = { name: d.name, type: d.type, contact: d.contact, tax_id: d.tax_id ?? '' }
+  errors.value = {}
+  modalOpen.value = true
+}
+async function submit() {
+  const res = validate(donorSchema, { ...form.value })
+  if (!res.ok) {
+    errors.value = res.errors
+    return
+  }
+  errors.value = {}
+  const payload: DonorPayload = {
+    name: res.data.name,
+    type: res.data.type,
+    contact: res.data.contact,
+    tax_id: res.data.tax_id?.trim() ? res.data.tax_id : null,
+  }
+  try {
+    if (editId.value != null) await update.mutateAsync({ id: editId.value, payload })
+    else await create.mutateAsync(payload)
+    toast.success(editId.value != null ? 'Donante actualizado' : 'Donante creado')
+    modalOpen.value = false
+  } catch (e) {
+    toast.error(apiErrorMessage(e, 'No se pudo guardar. ¿Ya existe un donante con ese nombre y tipo?'))
+  }
+}
+
+// --- Desactivar ---------------------------------------------------------------
+const confirmOpen = ref(false)
+const target = ref<Donor | null>(null)
+function askDeactivate(d: Donor) {
+  target.value = d
+  confirmOpen.value = true
+}
+async function confirmDeactivate() {
+  if (!target.value) return
+  try {
+    await deactivate.mutateAsync(target.value.id)
+    toast.success('Donante desactivado')
+  } catch (e) {
+    toast.error(apiErrorMessage(e))
+  } finally {
+    confirmOpen.value = false
+    target.value = null
+  }
+}
+</script>
+
+<template>
+  <section class="space-y-5">
+    <PageHeader
+      title="Donantes"
+      crumb="Ayudas"
+      :subtitle="total ? `${total} ${total === 1 ? 'donante' : 'donantes'}` : 'Personas y organizaciones donantes'"
+    >
+      <template #actions>
+        <RoleGate :roles="[...EDIT_ROLES]">
+          <AppButton @click="openCreate"><Plus /> Registrar donante</AppButton>
+        </RoleGate>
+      </template>
+    </PageHeader>
+
+    <div class="grid grid-cols-1 gap-3 rounded-lg border border-neutral-200 bg-white p-4 sm:grid-cols-3">
+      <SearchInput v-model="search" placeholder="Buscar por nombre…" />
+      <SelectField v-model="typeFilter" :options="typeFilterOptions" />
+      <SelectField v-model="statusFilter" :options="statusFilterOptions" />
+    </div>
+
+    <div v-if="isError" class="rounded-lg border border-danger-br bg-danger-bg p-6 text-center">
+      <p class="text-sm text-danger">No se pudieron cargar los donantes.</p>
+      <AppButton variant="outline" size="sm" class="mt-3" @click="() => refetch()"><RotateCcw /> Reintentar</AppButton>
+    </div>
+
+    <div v-else-if="isLoading" class="space-y-2 rounded-lg border border-neutral-200 bg-white p-4">
+      <SkeletonBlock v-for="n in 6" :key="n" height="44px" />
+    </div>
+
+    <template v-else>
+      <div :class="{ 'opacity-60 transition-opacity': isFetching }">
+        <DataTable :columns="columns" :rows="rows" row-key="id" min-width="820px">
+          <template #name="{ row }"><span class="font-semibold text-neutral-900">{{ asDonor(row).name }}</span></template>
+          <template #type="{ row }">
+            <span class="rounded-full bg-info-bg px-2.5 py-1 text-xs font-medium text-primary-700">
+              {{ DONOR_TYPE_LABELS[asDonor(row).type] }}
+            </span>
+          </template>
+          <template #contact="{ row }"><span class="text-sm text-neutral-600">{{ asDonor(row).contact }}</span></template>
+          <template #status="{ row }">
+            <span
+              :class="[
+                'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-semibold',
+                asDonor(row).is_active
+                  ? 'border-success-br bg-success-bg text-success'
+                  : 'border-neutral-200 bg-neutral-100 text-neutral-500',
+              ]"
+            >
+              {{ asDonor(row).is_active ? 'Activo' : 'Inactivo' }}
+            </span>
+          </template>
+          <template #actions="{ row }">
+            <div class="flex justify-end gap-1">
+              <AppButton variant="ghost" size="sm" @click="router.push(`/donors/${asDonor(row).id}`)"><Eye /> Ver</AppButton>
+              <RoleGate :roles="[...EDIT_ROLES]">
+                <AppButton variant="ghost" size="sm" @click="openEdit(asDonor(row))"><Pencil /></AppButton>
+              </RoleGate>
+              <RoleGate :roles="[...DELETE_ROLES]">
+                <AppButton v-if="asDonor(row).is_active" variant="ghost" size="sm" class="text-danger" @click="askDeactivate(asDonor(row))">
+                  <Ban />
+                </AppButton>
+              </RoleGate>
+            </div>
+          </template>
+          <template #empty>
+            <EmptyState
+              title="Sin donantes"
+              :message="hasFilters ? 'No hay donantes que coincidan con los filtros.' : 'Aún no se han registrado donantes.'"
+            >
+              <template #icon><SearchX /></template>
+              <template #action>
+                <AppButton v-if="hasFilters" variant="outline" size="sm" @click="clearFilters"><RotateCcw /> Limpiar filtros</AppButton>
+                <RoleGate v-else :roles="[...EDIT_ROLES]">
+                  <AppButton size="sm" @click="openCreate"><Plus /> Registrar donante</AppButton>
+                </RoleGate>
+              </template>
+            </EmptyState>
+          </template>
+        </DataTable>
+      </div>
+
+      <div v-if="total > 0" class="flex flex-wrap items-center justify-between gap-3 text-sm text-neutral-600">
+        <span>Mostrando <strong>{{ rangeFrom }}–{{ rangeTo }}</strong> de <strong>{{ total }}</strong></span>
+        <div class="flex items-center gap-2">
+          <AppButton variant="outline" size="sm" :disabled="page <= 1" @click="goTo(page - 1)"><ChevronLeft /></AppButton>
+          <span class="px-1">Página {{ page }} de {{ totalPages }}</span>
+          <AppButton variant="outline" size="sm" :disabled="page >= totalPages" @click="goTo(page + 1)"><ChevronRight /></AppButton>
+        </div>
+      </div>
+    </template>
+
+    <BaseModal
+      :open="modalOpen"
+      :title="editId != null ? 'Editar donante' : 'Nuevo donante'"
+      max-width="max-w-[560px]"
+      @close="modalOpen = false"
+    >
+      <form class="space-y-4" @submit.prevent="submit">
+        <FormField label="Nombre" required :error="errors.name" input-id="do-name">
+          <input id="do-name" v-model="form.name" class="control" placeholder="Nombre o razón social" />
+        </FormField>
+        <SelectField v-model="form.type" label="Tipo" required :options="typeFormOptions" :error="errors.type" input-id="do-type" />
+        <FormField label="Contacto" required :error="errors.contact" input-id="do-contact" hint="Teléfono, correo o persona de contacto (obligatorio).">
+          <input id="do-contact" v-model="form.contact" class="control" placeholder="Ej. 310 000 0000 / correo@…" />
+        </FormField>
+        <FormField label="NIT / Documento" :error="errors.tax_id" input-id="do-tax" hint="Opcional">
+          <input id="do-tax" v-model="form.tax_id" class="control" placeholder="Ej. 900123456-7" />
+        </FormField>
+      </form>
+      <template #footer>
+        <AppButton variant="ghost" @click="modalOpen = false">Cancelar</AppButton>
+        <AppButton :disabled="saving" @click="submit">
+          {{ saving ? 'Guardando…' : editId != null ? 'Guardar cambios' : 'Crear donante' }}
+        </AppButton>
+      </template>
+    </BaseModal>
+
+    <ConfirmDialog
+      :open="confirmOpen"
+      tone="warning"
+      title="Desactivar donante"
+      :message="target ? `“${target.name}” quedará inactivo. Se conserva su histórico de donaciones.` : ''"
+      confirm-label="Desactivar"
+      @confirm="confirmDeactivate"
+      @close="confirmOpen = false"
+    />
+  </section>
+</template>

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -115,6 +115,32 @@ const router = createRouter({
           component: () => import('@/pages/settings/AlertThresholdsPage.vue'),
           meta: { roles: ['ADMIN', 'COORDINADOR_LOGISTICA'] },
         },
+        // Ayudas — Donantes y Donaciones (HU-18/19/20). Lectura para editores +
+        // FUNCIONARIO_CONTROL (consulta); el alta solo para editores.
+        {
+          path: 'donors',
+          name: 'donors',
+          component: () => import('@/pages/donors/DonorsListPage.vue'),
+          meta: { roles: ['ADMIN', 'COORDINADOR_LOGISTICA', 'REGISTRADOR_DONACIONES', 'FUNCIONARIO_CONTROL'] },
+        },
+        {
+          path: 'donors/:id',
+          name: 'donor-detail',
+          component: () => import('@/pages/donors/DonorDetailPage.vue'),
+          meta: { roles: ['ADMIN', 'COORDINADOR_LOGISTICA', 'REGISTRADOR_DONACIONES', 'FUNCIONARIO_CONTROL'] },
+        },
+        {
+          path: 'donations',
+          name: 'donations',
+          component: () => import('@/pages/donations/DonationsListPage.vue'),
+          meta: { roles: ['ADMIN', 'COORDINADOR_LOGISTICA', 'REGISTRADOR_DONACIONES', 'FUNCIONARIO_CONTROL'] },
+        },
+        {
+          path: 'donations/new',
+          name: 'donation-new',
+          component: () => import('@/pages/donations/DonationFormPage.vue'),
+          meta: { roles: ['ADMIN', 'COORDINADOR_LOGISTICA', 'REGISTRADOR_DONACIONES'] },
+        },
         // Las demas rutas (entregas, mapa, etc.) se agregan aqui
         // a medida que se implementan las HU. Ver HistoriasDeUsuario.json.
       ],

--- a/client/src/schemas/donor.schema.ts
+++ b/client/src/schemas/donor.schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod'
+
+// Formulario de donante (HU-18). El contacto es obligatorio (CA2). La unicidad
+// (name, type) la valida el backend (409, CA3).
+export const donorSchema = z.object({
+  name: z.string().trim().min(2, 'Mínimo 2 caracteres').max(200, 'Máximo 200 caracteres'),
+  type: z.enum(['PERSONA_NATURAL', 'EMPRESA', 'ALCALDIA', 'GOBERNACION', 'ORGANIZACION'], {
+    message: 'Selecciona el tipo de donante',
+  }),
+  contact: z.string().trim().min(3, 'El contacto es obligatorio (mín. 3 caracteres)').max(200, 'Máximo 200 caracteres'),
+  tax_id: z.string().trim().max(30, 'Máximo 30 caracteres').optional(),
+})
+
+export type DonorFormValues = z.infer<typeof donorSchema>

--- a/client/src/types/donation.types.ts
+++ b/client/src/types/donation.types.ts
@@ -1,0 +1,79 @@
+// Tipos del módulo de donaciones. Reflejan server/src/types/entities.ts.
+import type { ResourceCategory } from './inventory.types'
+import type { Donor } from './donor.types'
+
+export type DonationType = 'IN_KIND' | 'MONETARY' | 'MIXED'
+
+export const DONATION_TYPE_OPTIONS: { value: DonationType; label: string }[] = [
+  { value: 'IN_KIND', label: 'En especie' },
+  { value: 'MONETARY', label: 'Monetaria' },
+  { value: 'MIXED', label: 'Mixta' },
+]
+
+export const DONATION_TYPE_LABELS = Object.fromEntries(
+  DONATION_TYPE_OPTIONS.map((o) => [o.value, o.label]),
+) as Record<DonationType, string>
+
+export interface DonationDetail {
+  id: number
+  resource_type_id: number
+  resource_name: string
+  category: ResourceCategory
+  quantity: number
+  weight_kg: number
+  batch: string | null
+  expiration_date?: string | null
+}
+
+export interface Donation {
+  id: number
+  donation_code: string
+  donor_id: number
+  destination_warehouse_id: number | null
+  donation_type: DonationType
+  monetary_amount: string | null // pg NUMERIC → string
+  date: string
+  notes: string | null
+  created_by: number | null
+  created_at: string
+  updated_at: string
+}
+
+// GET /donations y /donors/:id/donations devuelven la donación enriquecida con
+// el donante y los detalles (la vista del backend es passthrough; pueden faltar
+// según el endpoint, por eso son opcionales).
+export interface DonationEnriched extends Donation {
+  donor?: Donor
+  details?: DonationDetail[]
+}
+
+// Línea de ítem que envía el formulario (el peso lo calcula el backend si se omite).
+export interface DonationDetailInput {
+  resource_type_id: number
+  quantity: number
+  batch?: string | null
+  expiration_date?: string | null
+}
+
+// Cuerpo de POST /donations. Campos condicionales según donation_type:
+//  - IN_KIND  → destination_warehouse_id + details (sin monetary_amount)
+//  - MONETARY → monetary_amount (sin bodega ni details)
+//  - MIXED    → ambos
+export interface DonationPayload {
+  donor_id: number
+  donation_type: DonationType
+  date: string
+  notes?: string | null
+  destination_warehouse_id?: number
+  monetary_amount?: string
+  details?: DonationDetailInput[]
+}
+
+export interface DonationListParams {
+  page: number
+  limit: number
+  donor_id?: number
+  type?: DonationType
+  date_from?: string
+  date_to?: string
+}

--- a/client/src/types/donor.types.ts
+++ b/client/src/types/donor.types.ts
@@ -1,0 +1,42 @@
+// Tipos del módulo de donantes. Reflejan server/src/types/entities.ts.
+
+export type DonorType = 'PERSONA_NATURAL' | 'EMPRESA' | 'ALCALDIA' | 'GOBERNACION' | 'ORGANIZACION'
+
+export const DONOR_TYPE_OPTIONS: { value: DonorType; label: string }[] = [
+  { value: 'PERSONA_NATURAL', label: 'Persona natural' },
+  { value: 'EMPRESA', label: 'Empresa' },
+  { value: 'ALCALDIA', label: 'Alcaldía' },
+  { value: 'GOBERNACION', label: 'Gobernación' },
+  { value: 'ORGANIZACION', label: 'Organización' },
+]
+
+export const DONOR_TYPE_LABELS = Object.fromEntries(
+  DONOR_TYPE_OPTIONS.map((o) => [o.value, o.label]),
+) as Record<DonorType, string>
+
+export interface Donor {
+  id: number
+  name: string
+  type: DonorType
+  contact: string
+  tax_id: string | null
+  is_active: boolean
+  created_at?: string
+  updated_at?: string
+}
+
+export interface DonorListParams {
+  page: number
+  limit: number
+  type?: DonorType
+  is_active?: boolean
+  search?: string
+}
+
+// Cuerpo de POST/PUT /donors. Único por (name, type) (HU-18 CA3).
+export interface DonorPayload {
+  name: string
+  type: DonorType
+  contact: string
+  tax_id: string | null
+}


### PR DESCRIPTION
## Paso 7 del frontend (Vue): Donantes + Donaciones

> **PR apilado** sobre #64 → #63 → #62. Base: `feature/fe-warehouses-inventory-hu11-17`. **Mergear en orden: #62 → #63 → #64 → este.** GitHub re-apunta a `dev` al mergear los anteriores.

### Páginas
- **DonorsListPage** (`/donors`, HU-18): CRUD de donantes con **contacto obligatorio** (CA2); la **unicidad (name, type)** la valida el backend (409, CA3); filtros tipo/estado + paginación; **soft-delete** (desactivar).
- **DonorDetailPage** (`/donors/:id`, HU-20): datos del donante + **historial de donaciones** (total monetario, peso, ítems).
- **DonationsListPage** (`/donations`): tabla con filtros (donante, tipo, rango de fechas) y **modal de detalle** de ítems en especie.
- **DonationFormPage** (`/donations/new`, HU-19): formulario **multi-sección por tipo** (IN_KIND / MONETARY / MIXED), **ítems dinámicos** con **cálculo de peso automático** y **alerta si el peso estimado supera la capacidad disponible** de la bodega destino (CA3). Prefill de donante vía `?donor_id`.

### Soporte
- Tipos `donor.types.ts`, `donation.types.ts`; esquema `donor.schema.ts` (la validación condicional de la donación va imperativa en la página).
- API `donors`/`donations`; composables `useDonors`/`useDonations`.
- Rutas nuevas (lectura para editores + `FUNCIONARIO_CONTROL`; alta solo editores) e items de sidebar en **Ayudas** (Donantes, Donaciones).

### Notas de contrato (backend)
- Donación condicional: IN_KIND → `destination_warehouse_id` + `details`; MONETARY → `monetary_amount`; MIXED → ambos. El backend recalcula peso e inventario de la bodega destino.
- `DELETE /donors/:id` es **soft-delete** y devuelve el donante. Listado de donaciones filtra por `type`/`date_from`/`date_to`/`donor_id`.

### Verificación
- ✅ `pnpm -C client typecheck`
- ✅ `pnpm -C client build` (4 chunks nuevos generados)

🤖 Generated with [Claude Code](https://claude.com/claude-code)