### PR TITLE
feat(client): Priorización + ScoringConfig (Paso 8) — HU-08

### DIFF
--- a/client/src/api/prioritization.api.ts
+++ b/client/src/api/prioritization.api.ts
@@ -1,0 +1,19 @@
+import { api } from './axios'
+import type { ApiItem, ApiList } from '@/types/api.types'
+import type { RankingParams, RankingRow } from '@/types/prioritization.types'
+
+export const prioritizationApi = {
+  ranking(params: RankingParams) {
+    const query: Record<string, string | number> = { page: params.page, limit: params.limit }
+    if (params.zone_id) query.zone_id = params.zone_id
+    if (params.status) query.status = params.status
+    return api.get<ApiList<RankingRow>>('/prioritization/ranking', { params: query }).then((r) => r.data)
+  },
+
+  // POST /prioritization/recalculate (ADMIN/COORD) → { recalculated: N }.
+  recalculate() {
+    return api
+      .post<ApiItem<{ recalculated: number }>>('/prioritization/recalculate')
+      .then((r) => r.data.data)
+  },
+}

--- a/client/src/api/scoringConfig.api.ts
+++ b/client/src/api/scoringConfig.api.ts
@@ -1,0 +1,14 @@
+import { api } from './axios'
+import type { ApiItem } from '@/types/api.types'
+import type { ScoringConfigKey, ScoringConfigRow } from '@/types/prioritization.types'
+
+export const scoringConfigApi = {
+  list() {
+    return api.get<ApiItem<ScoringConfigRow[]>>('/scoring-config').then((r) => r.data.data)
+  },
+
+  // PUT /scoring-config acepta un par { key, value } por llamada (ADMIN/COORD).
+  set(key: ScoringConfigKey, value: number) {
+    return api.put<ApiItem<ScoringConfigRow>>('/scoring-config', { key, value }).then((r) => r.data.data)
+  },
+}

--- a/client/src/components/layout/AppSidebar.vue
+++ b/client/src/components/layout/AppSidebar.vue
@@ -17,6 +17,7 @@ import {
   Truck,
   HeartHandshake,
   Gift,
+  ListOrdered,
   Activity,
   BarChart3,
   Settings,
@@ -72,6 +73,7 @@ const groups: NavGroup[] = [
     title: 'Ayudas',
     items: [
       { label: 'Entregas', to: '/deliveries', icon: Truck },
+      { label: 'Ranking', to: '/deliveries/ranking', icon: ListOrdered },
       { label: 'Donantes', to: '/donors', icon: HeartHandshake, roles: ['ADMIN', 'COORDINADOR_LOGISTICA', 'REGISTRADOR_DONACIONES', 'FUNCIONARIO_CONTROL'] },
       { label: 'Donaciones', to: '/donations', icon: Gift, roles: ['ADMIN', 'COORDINADOR_LOGISTICA', 'REGISTRADOR_DONACIONES', 'FUNCIONARIO_CONTROL'] },
     ],

--- a/client/src/composables/usePrioritization.ts
+++ b/client/src/composables/usePrioritization.ts
@@ -1,0 +1,25 @@
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/vue-query'
+import type { Ref } from 'vue'
+import { prioritizationApi } from '@/api/prioritization.api'
+import type { RankingParams } from '@/types/prioritization.types'
+
+export function useRanking(params: Ref<RankingParams>) {
+  return useQuery({
+    queryKey: ['prioritization', 'ranking', params],
+    queryFn: () => prioritizationApi.ranking(params.value),
+    placeholderData: keepPreviousData,
+  })
+}
+
+// Recalcula y persiste el puntaje de todas las familias. Invalida ranking y
+// familias (el detalle muestra el puntaje vivo).
+export function useRecalculate() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: prioritizationApi.recalculate,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['prioritization'] })
+      qc.invalidateQueries({ queryKey: ['families'] })
+    },
+  })
+}

--- a/client/src/composables/useScoringConfig.ts
+++ b/client/src/composables/useScoringConfig.ts
@@ -1,0 +1,25 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query'
+import { scoringConfigApi } from '@/api/scoringConfig.api'
+import type { ScoringConfigKey } from '@/types/prioritization.types'
+
+export function useScoringConfig() {
+  return useQuery({
+    queryKey: ['scoring-config'],
+    queryFn: scoringConfigApi.list,
+  })
+}
+
+// Cada peso se guarda con un PUT { key, value }. Invalida la config y la
+// priorización (los pesos afectan futuros recálculos del puntaje).
+export function useScoringConfigMutations() {
+  const qc = useQueryClient()
+  const set = useMutation({
+    mutationFn: ({ key, value }: { key: ScoringConfigKey; value: number }) =>
+      scoringConfigApi.set(key, value),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['scoring-config'] })
+      qc.invalidateQueries({ queryKey: ['prioritization'] })
+    },
+  })
+  return { set }
+}

--- a/client/src/pages/deliveries/RankingPage.vue
+++ b/client/src/pages/deliveries/RankingPage.vue
@@ -1,0 +1,216 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { toast } from 'vue-sonner'
+import { RefreshCw, BarChart3, SearchX, RotateCcw, ChevronLeft, ChevronRight } from '@lucide/vue'
+import { useRanking, useRecalculate } from '@/composables/usePrioritization'
+import { useZones } from '@/composables/useZones'
+import { FAMILY_STATUS_OPTIONS } from '@/types/family.types'
+import type { FamilyScoreBreakdown, FamilyStatus } from '@/types/family.types'
+import type { RankingParams, RankingRow } from '@/types/prioritization.types'
+import { apiErrorMessage } from '@/utils/apiError'
+import PageHeader from '@/components/ui/PageHeader.vue'
+import AppButton from '@/components/ui/AppButton.vue'
+import DataTable from '@/components/ui/DataTable.vue'
+import EmptyState from '@/components/ui/EmptyState.vue'
+import SkeletonBlock from '@/components/ui/SkeletonBlock.vue'
+import FamilyStatusBadge from '@/components/ui/FamilyStatusBadge.vue'
+import RiskLevelBadge from '@/components/ui/RiskLevelBadge.vue'
+import ScoreBreakdown from '@/components/ui/ScoreBreakdown.vue'
+import BaseModal from '@/components/ui/BaseModal.vue'
+import SelectField from '@/components/form/SelectField.vue'
+import RoleGate from '@/components/auth/RoleGate.vue'
+
+const router = useRouter()
+const PAGE_SIZE = 20
+const RECALC_ROLES = ['ADMIN', 'COORDINADOR_LOGISTICA'] as const
+
+const zoneFilter = ref('')
+const statusFilter = ref('')
+const page = ref(1)
+
+const params = computed<RankingParams>(() => ({
+  page: page.value,
+  limit: PAGE_SIZE,
+  ...(zoneFilter.value ? { zone_id: Number(zoneFilter.value) } : {}),
+  ...(statusFilter.value ? { status: statusFilter.value as FamilyStatus } : {}),
+}))
+
+const { data, isLoading, isFetching, isError, refetch } = useRanking(params)
+const { data: zones } = useZones()
+const recalc = useRecalculate()
+
+const zoneMap = computed(() => new Map((zones.value ?? []).map((z) => [z.id, z])))
+const total = computed(() => data.value?.pagination.total ?? 0)
+const totalPages = computed(() => data.value?.pagination.totalPages ?? 1)
+const rangeFrom = computed(() => (total.value === 0 ? 0 : (page.value - 1) * PAGE_SIZE + 1))
+const rangeTo = computed(() => Math.min(page.value * PAGE_SIZE, total.value))
+const hasFilters = computed(() => !!(zoneFilter.value || statusFilter.value))
+
+// Filas con su posición global en el ranking.
+const rows = computed(() =>
+  (data.value?.data ?? []).map((r, i) => ({ ...r, _rank: rangeFrom.value + i })),
+)
+
+const zoneFilterOptions = computed(() => [
+  { value: '', label: 'Todas las zonas' },
+  ...(zones.value ?? []).map((z) => ({ value: String(z.id), label: z.name })),
+])
+const statusFilterOptions = [
+  { value: '', label: 'Todos los estados' },
+  ...FAMILY_STATUS_OPTIONS.map((s) => ({ value: s.value as string, label: s.label })),
+]
+
+const columns = [
+  { key: '_rank', label: '#', align: 'center' as const },
+  { key: 'family_code', label: 'Código', mono: true },
+  { key: 'zone', label: 'Zona' },
+  { key: 'num_members', label: 'Miembros', align: 'center' as const },
+  { key: 'priority_score', label: 'Puntaje', align: 'right' as const },
+  { key: 'status', label: 'Estado' },
+  { key: 'last_delivery_date', label: 'Última entrega' },
+  { key: 'actions', label: '', align: 'right' as const },
+]
+const asRow = (r: unknown) => r as RankingRow & { _rank: number }
+
+function fmtDate(s: string | null) {
+  return s ? new Date(s).toLocaleDateString('es-CO', { day: '2-digit', month: 'short', year: 'numeric' }) : 'Nunca'
+}
+function goTo(p: number) {
+  page.value = Math.min(Math.max(1, p), totalPages.value)
+}
+function clearFilters() {
+  zoneFilter.value = ''
+  statusFilter.value = ''
+}
+
+async function recalculate() {
+  try {
+    const res = await recalc.mutateAsync()
+    toast.success(`Puntajes recalculados (${res.recalculated} familias)`)
+  } catch (e) {
+    toast.error(apiErrorMessage(e))
+  }
+}
+
+// --- Modal de desglose --------------------------------------------------------
+const breakdownOpen = ref(false)
+const breakdownRow = ref<RankingRow | null>(null)
+function openBreakdown(r: RankingRow) {
+  breakdownRow.value = r
+  breakdownOpen.value = true
+}
+const breakdownFactors = computed(() => {
+  const b = breakdownRow.value?.priority_score_breakdown as FamilyScoreBreakdown | undefined
+  if (!b || typeof b.members !== 'number') return []
+  const raw = [
+    { name: 'Integrantes', points: b.members },
+    { name: 'Niños < 5', points: b.children_u5 },
+    { name: 'Adultos > 65', points: b.adults_o65 },
+    { name: 'Gestantes', points: b.pregnant },
+    { name: 'Discapacidad', points: b.disabled },
+    { name: 'Riesgo de zona', points: b.zone_risk },
+    { name: 'Días sin ayuda', points: b.days_no_aid },
+  ]
+  const maxPts = Math.max(1, ...raw.map((f) => f.points))
+  return raw.map((f) => ({ name: f.name, points: Math.round(f.points), max: Math.round(maxPts) }))
+})
+const breakdownPositiveSum = computed(() => breakdownFactors.value.reduce((a, f) => a + f.points, 0))
+</script>
+
+<template>
+  <section class="space-y-5">
+    <PageHeader
+      title="Ranking de prioridad"
+      crumb="Ayudas"
+      :subtitle="total ? `${total} familias priorizadas` : 'Familias ordenadas por puntaje de prioridad'"
+    >
+      <template #actions>
+        <RoleGate :roles="[...RECALC_ROLES]">
+          <AppButton variant="outline" :disabled="recalc.isPending.value" @click="recalculate">
+            <RefreshCw /> {{ recalc.isPending.value ? 'Recalculando…' : 'Recalcular todos' }}
+          </AppButton>
+        </RoleGate>
+      </template>
+    </PageHeader>
+
+    <div class="grid grid-cols-1 gap-3 rounded-lg border border-neutral-200 bg-white p-4 sm:grid-cols-2">
+      <SelectField v-model="zoneFilter" :options="zoneFilterOptions" />
+      <SelectField v-model="statusFilter" :options="statusFilterOptions" />
+    </div>
+
+    <div v-if="isError" class="rounded-lg border border-danger-br bg-danger-bg p-6 text-center">
+      <p class="text-sm text-danger">No se pudo cargar el ranking.</p>
+      <AppButton variant="outline" size="sm" class="mt-3" @click="() => refetch()"><RotateCcw /> Reintentar</AppButton>
+    </div>
+
+    <div v-else-if="isLoading" class="space-y-2 rounded-lg border border-neutral-200 bg-white p-4">
+      <SkeletonBlock v-for="n in 8" :key="n" height="44px" />
+    </div>
+
+    <template v-else>
+      <div :class="{ 'opacity-60 transition-opacity': isFetching }">
+        <DataTable :columns="columns" :rows="rows" row-key="id" min-width="900px">
+          <template #_rank="{ row }"><span class="font-mono font-semibold text-neutral-500">{{ asRow(row)._rank }}</span></template>
+          <template #family_code="{ row }">
+            <button class="font-semibold text-primary-700 hover:underline" @click="router.push(`/families/${asRow(row).id}`)">
+              {{ asRow(row).family_code }}
+            </button>
+          </template>
+          <template #zone="{ row }">
+            <div class="flex items-center gap-2">
+              <span>{{ zoneMap.get(asRow(row).zone_id)?.name ?? asRow(row).zone_name ?? '—' }}</span>
+              <RiskLevelBadge v-if="zoneMap.get(asRow(row).zone_id)" :level="zoneMap.get(asRow(row).zone_id)!.risk_level" />
+            </div>
+          </template>
+          <template #priority_score="{ row }"><span class="font-semibold text-neutral-900">{{ Math.round(asRow(row).priority_score) }}</span></template>
+          <template #status="{ row }"><FamilyStatusBadge :status="asRow(row).status" /></template>
+          <template #last_delivery_date="{ row }"><span class="text-sm text-neutral-600">{{ fmtDate(asRow(row).last_delivery_date) }}</span></template>
+          <template #actions="{ row }">
+            <AppButton variant="ghost" size="sm" @click="openBreakdown(asRow(row))"><BarChart3 /> Desglose</AppButton>
+          </template>
+          <template #empty>
+            <EmptyState
+              title="Sin familias"
+              :message="hasFilters ? 'No hay familias que coincidan con los filtros.' : 'Aún no hay familias para priorizar.'"
+            >
+              <template #icon><SearchX /></template>
+              <template v-if="hasFilters" #action>
+                <AppButton variant="outline" size="sm" @click="clearFilters"><RotateCcw /> Limpiar filtros</AppButton>
+              </template>
+            </EmptyState>
+          </template>
+        </DataTable>
+      </div>
+
+      <div v-if="total > 0" class="flex flex-wrap items-center justify-between gap-3 text-sm text-neutral-600">
+        <span>Mostrando <strong>{{ rangeFrom }}–{{ rangeTo }}</strong> de <strong>{{ total }}</strong></span>
+        <div class="flex items-center gap-2">
+          <AppButton variant="outline" size="sm" :disabled="page <= 1" @click="goTo(page - 1)"><ChevronLeft /></AppButton>
+          <span class="px-1">Página {{ page }} de {{ totalPages }}</span>
+          <AppButton variant="outline" size="sm" :disabled="page >= totalPages" @click="goTo(page + 1)"><ChevronRight /></AppButton>
+        </div>
+      </div>
+    </template>
+
+    <!-- Modal de desglose -->
+    <BaseModal
+      :open="breakdownOpen"
+      :title="breakdownRow ? `Desglose · ${breakdownRow.family_code}` : ''"
+      max-width="max-w-[480px]"
+      @close="breakdownOpen = false"
+    >
+      <ScoreBreakdown
+        v-if="breakdownRow && breakdownFactors.length"
+        :factors="breakdownFactors"
+        :total="Math.round(breakdownRow.priority_score)"
+        :out-of="Math.max(breakdownPositiveSum, Math.round(breakdownRow.priority_score), 1)"
+      />
+      <p v-else class="text-sm text-neutral-500">Sin desglose disponible.</p>
+      <template #footer>
+        <AppButton variant="ghost" @click="breakdownOpen = false">Cerrar</AppButton>
+        <AppButton v-if="breakdownRow" @click="router.push(`/families/${breakdownRow.id}`)">Ver familia</AppButton>
+      </template>
+    </BaseModal>
+  </section>
+</template>

--- a/client/src/pages/settings/ScoringConfigPage.vue
+++ b/client/src/pages/settings/ScoringConfigPage.vue
@@ -1,0 +1,123 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { toast } from 'vue-sonner'
+import { Save, Info, RotateCcw } from '@lucide/vue'
+import { useScoringConfig, useScoringConfigMutations } from '@/composables/useScoringConfig'
+import { SCORING_CONFIG_FIELDS } from '@/types/prioritization.types'
+import type { ScoringConfigKey } from '@/types/prioritization.types'
+import { apiErrorMessage } from '@/utils/apiError'
+import PageHeader from '@/components/ui/PageHeader.vue'
+import AppButton from '@/components/ui/AppButton.vue'
+import FormField from '@/components/form/FormField.vue'
+import SkeletonBlock from '@/components/ui/SkeletonBlock.vue'
+
+const router = useRouter()
+const { data: config, isLoading, isError, refetch } = useScoringConfig()
+const { set } = useScoringConfigMutations()
+
+const savedMap = computed(() => new Map((config.value ?? []).map((r) => [r.key, r.value])))
+const draft = ref<Record<string, string>>({})
+const saving = ref(false)
+
+function inputVal(key: ScoringConfigKey) {
+  return draft.value[key] ?? (savedMap.value.has(key) ? String(savedMap.value.get(key)) : '')
+}
+function onInput(key: ScoringConfigKey, v: string) {
+  draft.value[key] = v
+}
+function fieldError(key: ScoringConfigKey) {
+  const v = draft.value[key]
+  if (v === undefined) return ''
+  const n = Number(v)
+  if (v === '' || Number.isNaN(n)) return 'Número inválido'
+  if (n < 0) return 'No puede ser negativo'
+  return ''
+}
+function isDirty(key: ScoringConfigKey) {
+  const v = draft.value[key]
+  if (v === undefined || fieldError(key)) return false
+  return Number(v) !== savedMap.value.get(key)
+}
+const dirtyKeys = computed(() => SCORING_CONFIG_FIELDS.filter((f) => isDirty(f.key)).map((f) => f.key))
+const hasErrors = computed(() => SCORING_CONFIG_FIELDS.some((f) => !!fieldError(f.key)))
+
+async function saveAll() {
+  if (!dirtyKeys.value.length || hasErrors.value) return
+  saving.value = true
+  try {
+    for (const key of dirtyKeys.value) {
+      await set.mutateAsync({ key, value: Number(draft.value[key]) })
+    }
+    toast.success('Pesos del puntaje actualizados')
+    draft.value = {}
+  } catch (e) {
+    toast.error(apiErrorMessage(e))
+  } finally {
+    saving.value = false
+  }
+}
+function resetChanges() {
+  draft.value = {}
+}
+</script>
+
+<template>
+  <section class="mx-auto max-w-3xl space-y-5">
+    <PageHeader
+      title="Pesos del puntaje"
+      crumb="Configuración"
+      subtitle="Ajusta cómo se prioriza a las familias (RN-04, HU-08 CA5)"
+    />
+
+    <div class="flex items-start gap-2 rounded-md bg-primary-50 p-3 text-sm text-primary-800">
+      <Info class="mt-0.5 h-4 w-4 flex-none" />
+      <span>
+        Los nuevos pesos aplican a los próximos cálculos. Para reflejarlos en las familias existentes,
+        usa
+        <button class="font-semibold underline" @click="router.push('/deliveries/ranking')">Recalcular todos</button>
+        en el ranking.
+      </span>
+    </div>
+
+    <div v-if="isError" class="rounded-lg border border-danger-br bg-danger-bg p-6 text-center">
+      <p class="text-sm text-danger">No se pudo cargar la configuración.</p>
+      <AppButton variant="outline" size="sm" class="mt-3" @click="() => refetch()"><RotateCcw /> Reintentar</AppButton>
+    </div>
+
+    <div v-else-if="isLoading" class="space-y-2 rounded-lg border border-neutral-200 bg-white p-5">
+      <SkeletonBlock v-for="n in 9" :key="n" height="48px" />
+    </div>
+
+    <template v-else>
+      <div class="grid grid-cols-1 gap-4 rounded-lg border border-neutral-200 bg-white p-5 sm:grid-cols-2">
+        <FormField
+          v-for="f in SCORING_CONFIG_FIELDS"
+          :key="f.key"
+          :label="f.label"
+          :hint="f.description"
+          :error="fieldError(f.key)"
+          :input-id="`sc-${f.key}`"
+        >
+          <input
+            :id="`sc-${f.key}`"
+            type="number"
+            step="any"
+            min="0"
+            class="control"
+            :value="inputVal(f.key)"
+            @input="onInput(f.key, ($event.target as HTMLInputElement).value)"
+          />
+        </FormField>
+      </div>
+
+      <div class="flex items-center justify-end gap-3">
+        <span v-if="dirtyKeys.length" class="text-sm text-neutral-500">{{ dirtyKeys.length }} cambio(s) sin guardar</span>
+        <AppButton variant="ghost" :disabled="!dirtyKeys.length || saving" @click="resetChanges">Descartar</AppButton>
+        <AppButton :disabled="!dirtyKeys.length || hasErrors || saving" @click="saveAll">
+          <Save /> {{ saving ? 'Guardando…' : 'Guardar cambios' }}
+        </AppButton>
+      </div>
+    </template>
+  </section>
+</template>

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -141,6 +141,18 @@ const router = createRouter({
           component: () => import('@/pages/donations/DonationFormPage.vue'),
           meta: { roles: ['ADMIN', 'COORDINADOR_LOGISTICA', 'REGISTRADOR_DONACIONES'] },
         },
+        // Priorización (HU-08): ranking + editor de pesos del puntaje.
+        {
+          path: 'deliveries/ranking',
+          name: 'ranking',
+          component: () => import('@/pages/deliveries/RankingPage.vue'),
+        },
+        {
+          path: 'settings/scoring',
+          name: 'settings-scoring',
+          component: () => import('@/pages/settings/ScoringConfigPage.vue'),
+          meta: { roles: ['ADMIN', 'COORDINADOR_LOGISTICA'] },
+        },
         // Las demas rutas (entregas, mapa, etc.) se agregan aqui
         // a medida que se implementan las HU. Ver HistoriasDeUsuario.json.
       ],

--- a/client/src/types/prioritization.types.ts
+++ b/client/src/types/prioritization.types.ts
@@ -1,0 +1,61 @@
+// Tipos de priorización y configuración del puntaje (HU-08).
+import type { FamilyStatus } from './family.types'
+
+// Fila del ranking (GET /prioritization/ranking). priority_score_breakdown tiene
+// la forma de FamilyScoreBreakdown (ver family.types.ts).
+export interface RankingRow {
+  id: number
+  family_code: string
+  head_document: string
+  zone_id: number
+  zone_name: string
+  shelter_id: number | null
+  num_members: number
+  num_children_under_5: number
+  num_adults_over_65: number
+  num_pregnant: number
+  num_disabled: number
+  priority_score: number
+  priority_score_breakdown: Record<string, unknown>
+  status: FamilyStatus
+  last_delivery_date: string | null
+}
+
+export interface RankingParams {
+  page: number
+  limit: number
+  zone_id?: number
+  status?: FamilyStatus
+}
+
+// --- Configuración del puntaje (scoring-config) -------------------------------
+export type ScoringConfigKey =
+  | 'W_MEMBERS'
+  | 'W_CHILDREN_5'
+  | 'W_ADULTS_65'
+  | 'W_PREGNANT'
+  | 'W_DISABLED'
+  | 'W_ZONE_RISK'
+  | 'W_DAYS_NO_AID'
+  | 'W_DELIVERIES'
+  | 'MAX_DAYS'
+
+export interface ScoringConfigRow {
+  key: ScoringConfigKey
+  value: number
+  updated_by: number | null
+  updated_at: string
+}
+
+// Etiqueta + descripción de cada peso, en el orden de presentación del editor.
+export const SCORING_CONFIG_FIELDS: { key: ScoringConfigKey; label: string; description: string }[] = [
+  { key: 'W_MEMBERS', label: 'Peso por integrante', description: 'Puntos por cada miembro del núcleo familiar.' },
+  { key: 'W_CHILDREN_5', label: 'Peso por niño < 5', description: 'Puntos por cada menor de 5 años.' },
+  { key: 'W_ADULTS_65', label: 'Peso por adulto > 65', description: 'Puntos por cada adulto mayor de 65 años.' },
+  { key: 'W_PREGNANT', label: 'Peso por gestante', description: 'Puntos por cada gestante.' },
+  { key: 'W_DISABLED', label: 'Peso por discapacidad', description: 'Puntos por cada persona con discapacidad.' },
+  { key: 'W_ZONE_RISK', label: 'Peso por riesgo de zona', description: 'Multiplica el factor de riesgo de la zona (1 a 4).' },
+  { key: 'W_DAYS_NO_AID', label: 'Peso por día sin ayuda', description: 'Puntos por cada día sin recibir ayuda (hasta el tope).' },
+  { key: 'W_DELIVERIES', label: 'Penalización por entrega', description: 'Resta puntos por cada entrega ya recibida.' },
+  { key: 'MAX_DAYS', label: 'Tope de días sin ayuda', description: 'Máximo de días sin ayuda que se contabilizan.' },
+]


### PR DESCRIPTION
## Paso 8 del frontend (Vue): Priorización + ScoringConfig

PR directo contra `dev` (la pila de los pasos 3–7 ya fue mergeada).

### Páginas
- **RankingPage** (`/deliveries/ranking`, HU-08): tabla ordenada por `priority_score` desc con posición, zona + nivel de riesgo, puntaje y última entrega; filtros zona/estado + paginación. **"Ver desglose"** abre un modal con `ScoreBreakdown` (mapea `priority_score_breakdown`). **"Recalcular todos"** (ADMIN/COORD) → `POST /prioritization/recalculate`, toast con el conteo.
- **ScoringConfigPage** (`/settings/scoring`, HU-08 CA5): editor de los **9 pesos** (`W_MEMBERS`, `W_CHILDREN_5`, `W_ADULTS_65`, `W_PREGNANT`, `W_DISABLED`, `W_ZONE_RISK`, `W_DAYS_NO_AID`, `W_DELIVERIES`, `MAX_DAYS`) con etiqueta y descripción; guarda cada peso modificado y enlaza a "Recalcular" para aplicarlos a las familias existentes.

### Soporte
- `types/prioritization.types.ts`; api `prioritization`/`scoringConfig`; composables `usePrioritization`/`useScoringConfig`.
- Rutas `/deliveries/ranking` y `/settings/scoring`; item **"Ranking"** en el sidebar (Ayudas). "Puntaje" ya estaba enlazado.

### Notas de contrato (backend)
- `POST /prioritization/recalculate` → `{ recalculated: N }`.
- `PUT /scoring-config` recibe **un par `{ key, value }`** por llamada (no un array); el editor hace un PUT por peso modificado. El backend invalida su caché de pesos.

### Verificación
- ✅ `pnpm -C client typecheck`
- ✅ `pnpm -C client build` (RankingPage y ScoringConfigPage en el bundle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)