### PR TITLE
feat(client): Entregas (Paso 9) — HU-22/23/12

### DIFF
--- a/client/src/api/deliveries.api.ts
+++ b/client/src/api/deliveries.api.ts
@@ -1,0 +1,66 @@
+import { api, idempotent } from './axios'
+import type { ApiItem, ApiList } from '@/types/api.types'
+import type {
+  BatchResult,
+  Delivery,
+  DeliveryEligibility,
+  DeliveryEnriched,
+  DeliveryListParams,
+  DeliveryPayload,
+  DeliveryStatus,
+  ExceptionPayload,
+  NextBatchRow,
+} from '@/types/delivery.types'
+
+export const deliveriesApi = {
+  list(params: DeliveryListParams) {
+    const query: Record<string, string | number> = { page: params.page, limit: params.limit }
+    if (params.family_id) query.family_id = params.family_id
+    if (params.warehouse_id) query.warehouse_id = params.warehouse_id
+    if (params.status) query.status = params.status
+    if (params.date_from) query.date_from = params.date_from
+    if (params.date_to) query.date_to = params.date_to
+    return api.get<ApiList<DeliveryEnriched>>('/deliveries', { params: query }).then((r) => r.data)
+  },
+
+  getById(id: number) {
+    return api.get<ApiItem<DeliveryEnriched>>(`/deliveries/${id}`).then((r) => r.data.data)
+  },
+
+  eligibility(familyId: number) {
+    return api
+      .get<ApiItem<DeliveryEligibility>>('/deliveries/eligibility', { params: { family_id: familyId } })
+      .then((r) => r.data.data)
+  },
+
+  // Vista previa del próximo lote (top-N priorizadas con elegibilidad).
+  nextBatch(count: number) {
+    return api
+      .get<ApiItem<NextBatchRow[]>>('/prioritization/next-batch', { params: { count } })
+      .then((r) => r.data.data)
+  },
+
+  create(payload: DeliveryPayload, clientOpId?: string) {
+    return api
+      .post<ApiItem<Delivery>>('/deliveries', payload, clientOpId ? idempotent(clientOpId) : undefined)
+      .then((r) => r.data.data)
+  },
+
+  createException(payload: ExceptionPayload) {
+    return api.post<ApiItem<Delivery>>('/deliveries/exception', payload).then((r) => r.data.data)
+  },
+
+  // POST /deliveries/batch crea las top-N priorizadas (solo { count }).
+  createBatch(count: number) {
+    return api.post<ApiItem<BatchResult>>('/deliveries/batch', { count }).then((r) => r.data.data)
+  },
+
+  updateStatus(id: number, status: DeliveryStatus, received_by_document?: string) {
+    return api
+      .put<ApiItem<Delivery>>(`/deliveries/${id}/status`, {
+        status,
+        ...(received_by_document ? { received_by_document } : {}),
+      })
+      .then((r) => r.data.data)
+  },
+}

--- a/client/src/composables/useDeliveries.ts
+++ b/client/src/composables/useDeliveries.ts
@@ -1,0 +1,74 @@
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/vue-query'
+import { computed, type Ref } from 'vue'
+import { deliveriesApi } from '@/api/deliveries.api'
+import type {
+  DeliveryListParams, DeliveryPayload, DeliveryStatus, ExceptionPayload,
+} from '@/types/delivery.types'
+
+export function useDeliveriesList(params: Ref<DeliveryListParams>) {
+  return useQuery({
+    queryKey: ['deliveries', 'list', params],
+    queryFn: () => deliveriesApi.list(params.value),
+    placeholderData: keepPreviousData,
+  })
+}
+
+export function useDelivery(id: Ref<number>) {
+  return useQuery({
+    queryKey: ['deliveries', 'detail', id],
+    queryFn: () => deliveriesApi.getById(id.value),
+    enabled: computed(() => id.value > 0),
+  })
+}
+
+// Elegibilidad reactiva por familia (HU-23). Solo consulta con family_id válido.
+export function useDeliveryEligibility(familyId: Ref<number>) {
+  return useQuery({
+    queryKey: ['deliveries', 'eligibility', familyId],
+    queryFn: () => deliveriesApi.eligibility(familyId.value),
+    enabled: computed(() => familyId.value > 0),
+    retry: false,
+  })
+}
+
+export function useNextBatch(count: Ref<number>) {
+  return useQuery({
+    queryKey: ['prioritization', 'next-batch', count],
+    queryFn: () => deliveriesApi.nextBatch(count.value),
+    enabled: computed(() => count.value > 0),
+  })
+}
+
+// Una entrega descuenta inventario, cambia el peso de la bodega y recalcula el
+// puntaje de la familia → invalida deliveries/warehouses/inventory/prioritization/families.
+export function useDeliveryMutations() {
+  const qc = useQueryClient()
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: ['deliveries'] })
+    qc.invalidateQueries({ queryKey: ['warehouses'] })
+    qc.invalidateQueries({ queryKey: ['inventory'] })
+    qc.invalidateQueries({ queryKey: ['prioritization'] })
+    qc.invalidateQueries({ queryKey: ['families'] })
+  }
+
+  const create = useMutation({
+    mutationFn: ({ payload, clientOpId }: { payload: DeliveryPayload; clientOpId?: string }) =>
+      deliveriesApi.create(payload, clientOpId),
+    onSuccess: invalidate,
+  })
+  const createException = useMutation({
+    mutationFn: (payload: ExceptionPayload) => deliveriesApi.createException(payload),
+    onSuccess: invalidate,
+  })
+  const createBatch = useMutation({
+    mutationFn: (count: number) => deliveriesApi.createBatch(count),
+    onSuccess: invalidate,
+  })
+  const updateStatus = useMutation({
+    mutationFn: ({ id, status, received_by_document }: { id: number; status: DeliveryStatus; received_by_document?: string }) =>
+      deliveriesApi.updateStatus(id, status, received_by_document),
+    onSuccess: invalidate,
+  })
+
+  return { create, createException, createBatch, updateStatus }
+}

--- a/client/src/pages/deliveries/DeliveriesListPage.vue
+++ b/client/src/pages/deliveries/DeliveriesListPage.vue
@@ -1,0 +1,156 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import { Plus, Layers, Eye, SearchX, RotateCcw, ChevronLeft, ChevronRight } from '@lucide/vue'
+import { useDeliveriesList } from '@/composables/useDeliveries'
+import { useWarehouses } from '@/composables/useWarehouses'
+import { DELIVERY_STATUS_OPTIONS } from '@/types/delivery.types'
+import type { DeliveryEnriched, DeliveryListParams, DeliveryStatus } from '@/types/delivery.types'
+import PageHeader from '@/components/ui/PageHeader.vue'
+import AppButton from '@/components/ui/AppButton.vue'
+import DataTable from '@/components/ui/DataTable.vue'
+import EmptyState from '@/components/ui/EmptyState.vue'
+import SkeletonBlock from '@/components/ui/SkeletonBlock.vue'
+import StatusBadge from '@/components/ui/StatusBadge.vue'
+import SelectField from '@/components/form/SelectField.vue'
+import FormField from '@/components/form/FormField.vue'
+import RoleGate from '@/components/auth/RoleGate.vue'
+
+const router = useRouter()
+const PAGE_SIZE = 20
+const CREATE_ROLES = ['ADMIN', 'COORDINADOR_LOGISTICA', 'OPERADOR_ENTREGAS'] as const
+const BATCH_ROLES = ['ADMIN', 'COORDINADOR_LOGISTICA'] as const
+
+const statusFilter = ref('')
+const warehouseFilter = ref('')
+const dateFrom = ref('')
+const dateTo = ref('')
+const page = ref(1)
+watch([statusFilter, warehouseFilter, dateFrom, dateTo], () => {
+  page.value = 1
+})
+
+const params = computed<DeliveryListParams>(() => ({
+  page: page.value,
+  limit: PAGE_SIZE,
+  ...(statusFilter.value ? { status: statusFilter.value as DeliveryStatus } : {}),
+  ...(warehouseFilter.value ? { warehouse_id: Number(warehouseFilter.value) } : {}),
+  ...(dateFrom.value ? { date_from: dateFrom.value } : {}),
+  ...(dateTo.value ? { date_to: dateTo.value } : {}),
+}))
+
+const { data, isLoading, isFetching, isError, refetch } = useDeliveriesList(params)
+const { data: warehouses } = useWarehouses()
+
+const warehouseMap = computed(() => new Map((warehouses.value ?? []).map((w) => [w.id, w])))
+const rows = computed(() => data.value?.data ?? [])
+const total = computed(() => data.value?.pagination.total ?? 0)
+const totalPages = computed(() => data.value?.pagination.totalPages ?? 1)
+const rangeFrom = computed(() => (total.value === 0 ? 0 : (page.value - 1) * PAGE_SIZE + 1))
+const rangeTo = computed(() => Math.min(page.value * PAGE_SIZE, total.value))
+const hasFilters = computed(() => !!(statusFilter.value || warehouseFilter.value || dateFrom.value || dateTo.value))
+
+const statusOptions = [{ value: '', label: 'Todos los estados' }, ...DELIVERY_STATUS_OPTIONS.map((o) => ({ value: o.value as string, label: o.label }))]
+const warehouseOptions = computed(() => [
+  { value: '', label: 'Todas las bodegas' },
+  ...(warehouses.value ?? []).map((w) => ({ value: String(w.id), label: w.name })),
+])
+
+const columns = [
+  { key: 'delivery_code', label: 'Código', mono: true },
+  { key: 'family', label: 'Familia' },
+  { key: 'warehouse', label: 'Bodega' },
+  { key: 'delivery_date', label: 'Fecha' },
+  { key: 'coverage_days', label: 'Cobertura', align: 'center' as const },
+  { key: 'status', label: 'Estado' },
+  { key: 'actions', label: '', align: 'right' as const },
+]
+const asDelivery = (r: unknown) => r as DeliveryEnriched
+
+function fmtDate(s: string) {
+  return new Date(s).toLocaleDateString('es-CO', { day: '2-digit', month: 'short', year: 'numeric' })
+}
+function goTo(p: number) {
+  page.value = Math.min(Math.max(1, p), totalPages.value)
+}
+function clearFilters() {
+  statusFilter.value = ''
+  warehouseFilter.value = ''
+  dateFrom.value = ''
+  dateTo.value = ''
+}
+</script>
+
+<template>
+  <section class="space-y-5">
+    <PageHeader
+      title="Entregas"
+      crumb="Ayudas"
+      :subtitle="total ? `${total} ${total === 1 ? 'entrega' : 'entregas'}` : 'Entregas de ayuda humanitaria'"
+    >
+      <template #actions>
+        <RoleGate :roles="[...BATCH_ROLES]">
+          <AppButton variant="outline" @click="router.push('/deliveries/batch')"><Layers /> Por lote</AppButton>
+        </RoleGate>
+        <RoleGate :roles="[...CREATE_ROLES]">
+          <AppButton @click="router.push('/deliveries/new')"><Plus /> Crear entrega</AppButton>
+        </RoleGate>
+      </template>
+    </PageHeader>
+
+    <div class="grid grid-cols-1 gap-3 rounded-lg border border-neutral-200 bg-white p-4 sm:grid-cols-2 lg:grid-cols-4">
+      <SelectField v-model="statusFilter" :options="statusOptions" />
+      <SelectField v-model="warehouseFilter" :options="warehouseOptions" />
+      <FormField label="" input-id="dl-from"><input id="dl-from" v-model="dateFrom" type="date" class="control" /></FormField>
+      <FormField label="" input-id="dl-to"><input id="dl-to" v-model="dateTo" type="date" class="control" /></FormField>
+    </div>
+
+    <div v-if="isError" class="rounded-lg border border-danger-br bg-danger-bg p-6 text-center">
+      <p class="text-sm text-danger">No se pudieron cargar las entregas.</p>
+      <AppButton variant="outline" size="sm" class="mt-3" @click="() => refetch()"><RotateCcw /> Reintentar</AppButton>
+    </div>
+
+    <div v-else-if="isLoading" class="space-y-2 rounded-lg border border-neutral-200 bg-white p-4">
+      <SkeletonBlock v-for="n in 6" :key="n" height="44px" />
+    </div>
+
+    <template v-else>
+      <div :class="{ 'opacity-60 transition-opacity': isFetching }">
+        <DataTable :columns="columns" :rows="rows" row-key="id" min-width="880px">
+          <template #delivery_code="{ row }"><span class="font-semibold text-neutral-900">{{ asDelivery(row).delivery_code }}</span></template>
+          <template #family="{ row }">{{ asDelivery(row).family?.family_code ?? `#${asDelivery(row).family_id}` }}</template>
+          <template #warehouse="{ row }">{{ asDelivery(row).warehouse?.name ?? warehouseMap.get(asDelivery(row).source_warehouse_id)?.name ?? '—' }}</template>
+          <template #delivery_date="{ row }">{{ fmtDate(asDelivery(row).delivery_date) }}</template>
+          <template #coverage_days="{ row }">{{ asDelivery(row).coverage_days }} días</template>
+          <template #status="{ row }"><StatusBadge :status="asDelivery(row).status" /></template>
+          <template #actions="{ row }">
+            <AppButton variant="ghost" size="sm" @click="router.push(`/deliveries/${asDelivery(row).id}`)"><Eye /> Ver</AppButton>
+          </template>
+          <template #empty>
+            <EmptyState
+              title="Sin entregas"
+              :message="hasFilters ? 'No hay entregas que coincidan con los filtros.' : 'Aún no se han registrado entregas.'"
+            >
+              <template #icon><SearchX /></template>
+              <template #action>
+                <AppButton v-if="hasFilters" variant="outline" size="sm" @click="clearFilters"><RotateCcw /> Limpiar filtros</AppButton>
+                <RoleGate v-else :roles="[...CREATE_ROLES]">
+                  <AppButton size="sm" @click="router.push('/deliveries/new')"><Plus /> Crear entrega</AppButton>
+                </RoleGate>
+              </template>
+            </EmptyState>
+          </template>
+        </DataTable>
+      </div>
+
+      <div v-if="total > 0" class="flex flex-wrap items-center justify-between gap-3 text-sm text-neutral-600">
+        <span>Mostrando <strong>{{ rangeFrom }}–{{ rangeTo }}</strong> de <strong>{{ total }}</strong></span>
+        <div class="flex items-center gap-2">
+          <AppButton variant="outline" size="sm" :disabled="page <= 1" @click="goTo(page - 1)"><ChevronLeft /></AppButton>
+          <span class="px-1">Página {{ page }} de {{ totalPages }}</span>
+          <AppButton variant="outline" size="sm" :disabled="page >= totalPages" @click="goTo(page + 1)"><ChevronRight /></AppButton>
+        </div>
+      </div>
+    </template>
+  </section>
+</template>

--- a/client/src/pages/deliveries/DeliveryBatchPage.vue
+++ b/client/src/pages/deliveries/DeliveryBatchPage.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { toast } from 'vue-sonner'
+import { ArrowLeft, Layers, CheckCircle2, XCircle, RotateCcw } from '@lucide/vue'
+import { useNextBatch, useDeliveryMutations } from '@/composables/useDeliveries'
+import type { NextBatchRow } from '@/types/delivery.types'
+import { apiErrorMessage } from '@/utils/apiError'
+import PageHeader from '@/components/ui/PageHeader.vue'
+import AppButton from '@/components/ui/AppButton.vue'
+import DataTable from '@/components/ui/DataTable.vue'
+import EmptyState from '@/components/ui/EmptyState.vue'
+import SkeletonBlock from '@/components/ui/SkeletonBlock.vue'
+import FormField from '@/components/form/FormField.vue'
+
+const router = useRouter()
+const countInput = ref('10')
+const count = computed(() => {
+  const n = Number(countInput.value)
+  return Number.isInteger(n) && n >= 1 && n <= 100 ? n : 0
+})
+
+const { data, isLoading, isFetching, isError, refetch } = useNextBatch(count)
+const { createBatch } = useDeliveryMutations()
+
+const rows = computed(() => data.value ?? [])
+const eligibleCount = computed(() => rows.value.filter((r) => r.eligibility.is_eligible).length)
+const asRow = (r: unknown) => r as NextBatchRow
+
+const columns = [
+  { key: 'family_code', label: 'Código', mono: true },
+  { key: 'zone_name', label: 'Zona' },
+  { key: 'num_members', label: 'Miembros', align: 'center' as const },
+  { key: 'priority_score', label: 'Puntaje', align: 'right' as const },
+  { key: 'eligibility', label: 'Elegible', align: 'center' as const },
+]
+
+async function execute() {
+  if (!count.value) {
+    toast.error('Ingresa una cantidad entre 1 y 100.')
+    return
+  }
+  try {
+    const res = await createBatch.mutateAsync(count.value)
+    toast.success(`${res.created} entrega(s) creada(s)`)
+    router.push('/deliveries')
+  } catch (e) {
+    toast.error(apiErrorMessage(e, 'No se pudo crear el lote.'))
+  }
+}
+</script>
+
+<template>
+  <section class="space-y-5">
+    <PageHeader title="Entrega por lote" crumb="Ayudas" subtitle="Crea entregas para las familias más prioritarias (HU-21/22)">
+      <template #actions>
+        <AppButton variant="outline" @click="router.push('/deliveries')"><ArrowLeft /> Volver</AppButton>
+      </template>
+    </PageHeader>
+
+    <div class="flex flex-wrap items-end gap-3 rounded-lg border border-neutral-200 bg-white p-4">
+      <div class="w-40">
+        <FormField label="Cantidad (N)" input-id="b-count" hint="1 a 100">
+          <input id="b-count" v-model="countInput" type="number" min="1" max="100" class="control" />
+        </FormField>
+      </div>
+      <AppButton :disabled="createBatch.isPending.value || !count" @click="execute">
+        <Layers /> {{ createBatch.isPending.value ? 'Creando…' : `Crear lote (${eligibleCount} elegibles)` }}
+      </AppButton>
+    </div>
+
+    <div v-if="isError" class="rounded-lg border border-danger-br bg-danger-bg p-6 text-center">
+      <p class="text-sm text-danger">No se pudo cargar la vista previa.</p>
+      <AppButton variant="outline" size="sm" class="mt-3" @click="() => refetch()"><RotateCcw /> Reintentar</AppButton>
+    </div>
+    <div v-else-if="isLoading" class="space-y-2 rounded-lg border border-neutral-200 bg-white p-4">
+      <SkeletonBlock v-for="n in 6" :key="n" height="40px" />
+    </div>
+    <div v-else :class="{ 'opacity-60 transition-opacity': isFetching }">
+      <p class="mb-2 text-sm text-neutral-500">Vista previa de las {{ rows.length }} familias mejor priorizadas:</p>
+      <DataTable :columns="columns" :rows="rows" row-key="id" min-width="640px">
+        <template #family_code="{ row }"><span class="font-semibold text-neutral-900">{{ asRow(row).family_code }}</span></template>
+        <template #priority_score="{ row }"><span class="font-semibold">{{ Math.round(asRow(row).priority_score) }}</span></template>
+        <template #eligibility="{ row }">
+          <span v-if="asRow(row).eligibility.is_eligible" class="inline-flex items-center gap-1 text-xs font-semibold text-success">
+            <CheckCircle2 class="h-4 w-4" /> Sí
+          </span>
+          <span v-else class="inline-flex items-center gap-1 text-xs font-semibold text-warning" :title="asRow(row).eligibility.reason">
+            <XCircle class="h-4 w-4" /> No
+          </span>
+        </template>
+        <template #empty>
+          <EmptyState title="Sin familias" message="No hay familias priorizadas para generar un lote.">
+            <template #icon><Layers /></template>
+          </EmptyState>
+        </template>
+      </DataTable>
+    </div>
+  </section>
+</template>

--- a/client/src/pages/deliveries/DeliveryDetailPage.vue
+++ b/client/src/pages/deliveries/DeliveryDetailPage.vue
@@ -1,0 +1,129 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { toast } from 'vue-sonner'
+import { ArrowLeft, RotateCcw, PlayCircle, CheckCircle2, ShieldAlert } from '@lucide/vue'
+import { useDelivery, useDeliveryMutations } from '@/composables/useDeliveries'
+import { DELIVERY_STATUS_LABELS } from '@/types/delivery.types'
+import type { DeliveryDetail, DeliveryStatus } from '@/types/delivery.types'
+import { apiErrorMessage } from '@/utils/apiError'
+import PageHeader from '@/components/ui/PageHeader.vue'
+import AppButton from '@/components/ui/AppButton.vue'
+import DataTable from '@/components/ui/DataTable.vue'
+import SkeletonBlock from '@/components/ui/SkeletonBlock.vue'
+import StatusBadge from '@/components/ui/StatusBadge.vue'
+import MapPicker from '@/components/form/MapPicker.vue'
+import BaseModal from '@/components/ui/BaseModal.vue'
+import FormField from '@/components/form/FormField.vue'
+import RoleGate from '@/components/auth/RoleGate.vue'
+
+const route = useRoute()
+const router = useRouter()
+const deliveryId = computed(() => Number(route.params.id))
+const STATUS_ROLES = ['ADMIN', 'COORDINADOR_LOGISTICA', 'OPERADOR_ENTREGAS'] as const
+
+const { data: delivery, isLoading, isError, refetch } = useDelivery(deliveryId)
+const { updateStatus } = useDeliveryMutations()
+
+const columns = [
+  { key: 'resource_name', label: 'Recurso' },
+  { key: 'quantity', label: 'Cantidad', align: 'right' as const },
+  { key: 'weight_kg', label: 'Peso', align: 'right' as const },
+  { key: 'batch', label: 'Lote' },
+]
+const asItem = (r: unknown) => r as DeliveryDetail
+
+function fmtDateTime(s: string) {
+  return new Date(s).toLocaleString('es-CO', { dateStyle: 'medium', timeStyle: 'short' })
+}
+
+async function setStatus(status: DeliveryStatus, doc?: string) {
+  try {
+    await updateStatus.mutateAsync({ id: deliveryId.value, status, received_by_document: doc })
+    toast.success(`Entrega marcada como ${DELIVERY_STATUS_LABELS[status].toLowerCase()}`)
+    deliverModalOpen.value = false
+  } catch (e) {
+    toast.error(apiErrorMessage(e))
+  }
+}
+
+// Modal para "marcar entregada" (captura documento de quien recibe).
+const deliverModalOpen = ref(false)
+const receivedBy = ref('')
+function openDeliver() {
+  receivedBy.value = delivery.value?.received_by_document ?? ''
+  deliverModalOpen.value = true
+}
+</script>
+
+<template>
+  <section class="space-y-5">
+    <div v-if="isLoading" class="space-y-4"><SkeletonBlock height="120px" /><SkeletonBlock height="160px" /></div>
+    <div v-else-if="isError || !delivery" class="rounded-lg border border-danger-br bg-danger-bg p-6 text-center">
+      <p class="text-sm text-danger">No se pudo cargar la entrega.</p>
+      <AppButton variant="outline" size="sm" class="mt-3" @click="() => refetch()"><RotateCcw /> Reintentar</AppButton>
+    </div>
+
+    <template v-else>
+      <PageHeader :title="delivery.delivery_code" crumb="Entregas">
+        <template #actions>
+          <AppButton variant="outline" @click="router.push('/deliveries')"><ArrowLeft /> Volver</AppButton>
+          <RoleGate :roles="[...STATUS_ROLES]">
+            <AppButton v-if="delivery.status === 'PROGRAMADA'" :disabled="updateStatus.isPending.value" @click="setStatus('EN_CURSO')">
+              <PlayCircle /> Iniciar
+            </AppButton>
+            <AppButton v-else-if="delivery.status === 'EN_CURSO'" :disabled="updateStatus.isPending.value" @click="openDeliver">
+              <CheckCircle2 /> Marcar entregada
+            </AppButton>
+          </RoleGate>
+        </template>
+      </PageHeader>
+
+      <div class="rounded-lg border border-neutral-200 bg-white p-5">
+        <div class="mb-4 flex flex-wrap items-center gap-3">
+          <StatusBadge :status="delivery.status" />
+          <span v-if="delivery.exception_reason" class="inline-flex items-center gap-1 rounded-full bg-warning-bg px-2.5 py-1 text-xs font-semibold text-warning">
+            <ShieldAlert class="h-3.5 w-3.5" /> Excepción
+          </span>
+        </div>
+        <dl class="grid grid-cols-2 gap-4 text-sm sm:grid-cols-3">
+          <div><dt class="text-neutral-500">Familia</dt><dd class="font-medium text-neutral-900">{{ delivery.family?.family_code ?? `#${delivery.family_id}` }}</dd></div>
+          <div><dt class="text-neutral-500">Bodega</dt><dd class="font-medium text-neutral-900">{{ delivery.warehouse?.name ?? `#${delivery.source_warehouse_id}` }}</dd></div>
+          <div><dt class="text-neutral-500">Fecha</dt><dd class="font-medium text-neutral-900">{{ fmtDateTime(delivery.delivery_date) }}</dd></div>
+          <div><dt class="text-neutral-500">Cobertura</dt><dd class="font-medium text-neutral-900">{{ delivery.coverage_days }} días</dd></div>
+          <div><dt class="text-neutral-500">Recibido por</dt><dd class="font-medium text-neutral-900">{{ delivery.received_by_document || '—' }}</dd></div>
+        </dl>
+        <p v-if="delivery.exception_reason" class="mt-3 rounded-md bg-warning-bg p-3 text-sm text-warning">
+          <strong>Excepción:</strong> {{ delivery.exception_reason }}
+        </p>
+        <p v-if="delivery.notes" class="mt-3 rounded-md bg-neutral-50 p-3 text-sm text-neutral-600">{{ delivery.notes }}</p>
+      </div>
+
+      <h2 class="text-sm font-semibold text-neutral-700">Ítems entregados</h2>
+      <DataTable :columns="columns" :rows="delivery.details ?? []" row-key="id" min-width="560px">
+        <template #resource_name="{ row }"><span class="font-medium text-neutral-900">{{ asItem(row).resource_name }}</span></template>
+        <template #quantity="{ row }"><span class="font-mono">{{ asItem(row).quantity }}</span></template>
+        <template #weight_kg="{ row }"><span class="font-mono text-xs">{{ Math.round(asItem(row).weight_kg).toLocaleString('es-CO') }} kg</span></template>
+        <template #batch="{ row }">{{ asItem(row).batch || '—' }}</template>
+        <template #empty><p class="py-6 text-center text-sm text-neutral-500">Sin ítems registrados.</p></template>
+      </DataTable>
+
+      <div v-if="delivery.delivery_latitude != null && delivery.delivery_longitude != null" class="rounded-lg border border-neutral-200 bg-white p-2">
+        <MapPicker :latitude="delivery.delivery_latitude" :longitude="delivery.delivery_longitude" readonly height="220px" />
+      </div>
+    </template>
+
+    <!-- Modal marcar entregada -->
+    <BaseModal :open="deliverModalOpen" title="Marcar como entregada" max-width="max-w-[420px]" @close="deliverModalOpen = false">
+      <FormField label="Recibido por (documento)" input-id="dd-rec" hint="Opcional">
+        <input id="dd-rec" v-model="receivedBy" class="control" placeholder="Documento de quien recibe" />
+      </FormField>
+      <template #footer>
+        <AppButton variant="ghost" @click="deliverModalOpen = false">Cancelar</AppButton>
+        <AppButton :disabled="updateStatus.isPending.value" @click="setStatus('ENTREGADA', receivedBy.trim() || undefined)">
+          {{ updateStatus.isPending.value ? 'Guardando…' : 'Confirmar entrega' }}
+        </AppButton>
+      </template>
+    </BaseModal>
+  </section>
+</template>

--- a/client/src/pages/deliveries/DeliveryFormPage.vue
+++ b/client/src/pages/deliveries/DeliveryFormPage.vue
@@ -1,0 +1,293 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { toast } from 'vue-sonner'
+import {
+  ArrowLeft, Save, Plus, Trash2, Search, CheckCircle2, XCircle, ShieldAlert,
+} from '@lucide/vue'
+import { useFamiliesList } from '@/composables/useFamilies'
+import { useDeliveryEligibility, useDeliveryMutations } from '@/composables/useDeliveries'
+import { useWarehouses } from '@/composables/useWarehouses'
+import { useResourceTypes } from '@/composables/useResourceTypes'
+import { useAuthStore } from '@/stores/auth'
+import type { Family, FamilyListParams } from '@/types/family.types'
+import type { DeliveryDetailInput, DeliveryPayload, ExceptionPayload } from '@/types/delivery.types'
+import type { ResourceTypeListParams } from '@/types/inventory.types'
+import { FOOD_KG_PER_PERSON_DAY, MIN_COVERAGE_DAYS } from '@/utils/constants'
+import { apiErrorMessage } from '@/utils/apiError'
+import PageHeader from '@/components/ui/PageHeader.vue'
+import AppButton from '@/components/ui/AppButton.vue'
+import FormField from '@/components/form/FormField.vue'
+import SelectField from '@/components/form/SelectField.vue'
+import MapPicker from '@/components/form/MapPicker.vue'
+
+const router = useRouter()
+const auth = useAuthStore()
+const isCoord = computed(() => auth.hasRole('COORDINADOR_LOGISTICA'))
+
+// --- Familia (búsqueda + selección) -------------------------------------------
+const familyQuery = ref('')
+const selectedFamily = ref<Family | null>(null)
+const searchParams = computed<FamilyListParams>(() => ({
+  page: 1,
+  limit: 8,
+  ...(familyQuery.value.trim().length >= 2 ? { q: familyQuery.value.trim() } : {}),
+}))
+const { data: familyResults } = useFamiliesList(searchParams)
+const showResults = computed(() => familyQuery.value.trim().length >= 2 && !selectedFamily.value)
+
+function pickFamily(f: Family) {
+  selectedFamily.value = f
+  familyQuery.value = ''
+}
+function clearFamily() {
+  selectedFamily.value = null
+}
+
+const familyId = computed(() => selectedFamily.value?.id ?? 0)
+const { data: eligibility, isFetching: checkingElig } = useDeliveryEligibility(familyId)
+
+// --- Bodega + recursos --------------------------------------------------------
+const { data: warehouses } = useWarehouses()
+const activeResourceParams = ref<ResourceTypeListParams>({ is_active: true })
+const { data: resourceTypes } = useResourceTypes(activeResourceParams)
+const warehouseOptions = computed(() => [
+  { value: '', label: 'Selecciona la bodega…' },
+  ...(warehouses.value ?? []).map((w) => ({ value: String(w.id), label: w.name })),
+])
+const resourceOptions = computed(() => [
+  { value: '', label: 'Recurso…' },
+  ...(resourceTypes.value ?? []).map((rt) => ({ value: String(rt.id), label: `${rt.name} (${rt.unit_of_measure})` })),
+])
+
+const warehouseId = ref('')
+const coverageDays = ref('7')
+const receivedBy = ref('')
+const notes = ref('')
+const latitude = ref<number | null>(null)
+const longitude = ref<number | null>(null)
+
+interface ItemRow {
+  resource_type_id: string
+  quantity: string
+  batch: string
+}
+const items = ref<ItemRow[]>([{ resource_type_id: '', quantity: '', batch: '' }])
+function addItem() {
+  items.value.push({ resource_type_id: '', quantity: '', batch: '' })
+}
+function removeItem(i: number) {
+  items.value.splice(i, 1)
+}
+
+// Cobertura mínima de alimentos sugerida (RN-01): 0,6 kg/persona/día.
+const suggestedFoodKg = computed(() => {
+  const members = selectedFamily.value?.num_members ?? 0
+  const days = Number(coverageDays.value) || 0
+  return members * days * FOOD_KG_PER_PERSON_DAY
+})
+
+// --- Excepción (HU-23 CA5) ----------------------------------------------------
+const exceptionMode = ref(false)
+const exceptionReason = ref('')
+const isEligible = computed(() => eligibility.value?.is_eligible ?? true)
+// Si no es elegible y no se autoriza excepción, el envío se bloquea.
+const blockedByCoverage = computed(() => !isEligible.value && !exceptionMode.value)
+
+const { create, createException } = useDeliveryMutations()
+const saving = computed(() => create.isPending.value || createException.isPending.value)
+const clientOpId = ref(crypto.randomUUID())
+
+const errors = ref<Record<string, string>>({})
+function validateForm() {
+  const e: Record<string, string> = {}
+  if (!selectedFamily.value) e.family = 'Selecciona una familia.'
+  if (!warehouseId.value) e.warehouse = 'Selecciona la bodega de origen.'
+  const cd = Number(coverageDays.value)
+  if (!coverageDays.value || Number.isNaN(cd) || cd < MIN_COVERAGE_DAYS) {
+    e.coverage = `La cobertura mínima es ${MIN_COVERAGE_DAYS} días (RN-01).`
+  }
+  if (!items.value.length || items.value.some((it) => !it.resource_type_id || !it.quantity || Number(it.quantity) <= 0 || !Number.isInteger(Number(it.quantity)))) {
+    e.details = 'Cada ítem requiere un recurso y una cantidad entera mayor que 0.'
+  }
+  if (exceptionMode.value && exceptionReason.value.trim().length < 5) {
+    e.exception = 'La justificación de la excepción es obligatoria (mín. 5 caracteres).'
+  }
+  errors.value = e
+  return Object.keys(e).length === 0
+}
+
+function buildDetails(): DeliveryDetailInput[] {
+  return items.value.map((it) => ({
+    resource_type_id: Number(it.resource_type_id),
+    quantity: Number(it.quantity),
+    batch: it.batch.trim() || null,
+  }))
+}
+
+async function submit() {
+  if (!validateForm() || !selectedFamily.value) return
+  const base = {
+    family_id: selectedFamily.value.id,
+    source_warehouse_id: Number(warehouseId.value),
+    coverage_days: Number(coverageDays.value),
+    received_by_document: receivedBy.value.trim() || null,
+    delivery_latitude: latitude.value,
+    delivery_longitude: longitude.value,
+    notes: notes.value.trim() || null,
+    details: buildDetails(),
+  }
+  try {
+    if (exceptionMode.value) {
+      const payload: ExceptionPayload = {
+        ...base,
+        exception_reason: exceptionReason.value.trim(),
+        exception_authorized_by: auth.user!.id,
+      }
+      const created = await createException.mutateAsync(payload)
+      toast.success(`Entrega ${created.delivery_code} creada con excepción`)
+    } else {
+      const payload: DeliveryPayload = { ...base, client_op_id: clientOpId.value }
+      const created = await create.mutateAsync({ payload, clientOpId: clientOpId.value })
+      toast.success(`Entrega ${created.delivery_code} registrada`)
+    }
+    router.push('/deliveries')
+  } catch (e) {
+    toast.error(apiErrorMessage(e, 'No se pudo registrar la entrega.'))
+  }
+}
+</script>
+
+<template>
+  <section class="mx-auto max-w-3xl space-y-5">
+    <PageHeader title="Crear entrega" crumb="Ayudas" subtitle="Entrega individual de ayuda a una familia">
+      <template #actions>
+        <AppButton variant="outline" @click="router.push('/deliveries')"><ArrowLeft /> Volver</AppButton>
+      </template>
+    </PageHeader>
+
+    <form class="space-y-5" @submit.prevent="submit">
+      <!-- 1. Familia -->
+      <fieldset class="space-y-3 rounded-lg border border-neutral-200 bg-white p-5">
+        <legend class="px-1 text-sm font-semibold text-neutral-700">1 · Familia</legend>
+
+        <div v-if="!selectedFamily">
+          <FormField label="Buscar familia" :error="errors.family" input-id="dv-fam" hint="Por código, documento o dirección (mín. 2 caracteres).">
+            <div class="relative">
+              <Search class="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-neutral-400" />
+              <input id="dv-fam" v-model="familyQuery" class="control pl-9" placeholder="FAM-2026-… / documento / dirección" />
+            </div>
+          </FormField>
+          <ul v-if="showResults" class="mt-2 max-h-60 divide-y divide-neutral-100 overflow-y-auto rounded-md border border-neutral-200">
+            <li v-for="f in (familyResults?.data ?? [])" :key="f.id">
+              <button type="button" class="flex w-full items-center justify-between px-3 py-2 text-left text-sm hover:bg-primary-50" @click="pickFamily(f)">
+                <span><span class="font-semibold text-neutral-900">{{ f.family_code }}</span> · <span class="font-mono text-xs">{{ f.head_document }}</span></span>
+                <span class="text-xs text-neutral-500">{{ f.num_members }} miembros</span>
+              </button>
+            </li>
+            <li v-if="!(familyResults?.data ?? []).length" class="px-3 py-3 text-center text-sm text-neutral-500">Sin resultados.</li>
+          </ul>
+        </div>
+
+        <div v-else class="space-y-3">
+          <div class="flex items-center justify-between rounded-md border border-neutral-200 bg-neutral-50 p-3">
+            <span class="text-sm">
+              <span class="font-semibold text-neutral-900">{{ selectedFamily.family_code }}</span>
+              · {{ selectedFamily.num_members }} miembros · doc {{ selectedFamily.head_document }}
+            </span>
+            <AppButton type="button" variant="ghost" size="sm" @click="clearFamily">Cambiar</AppButton>
+          </div>
+
+          <!-- Elegibilidad -->
+          <div v-if="checkingElig" class="text-sm text-neutral-500">Verificando elegibilidad…</div>
+          <div
+            v-else-if="eligibility"
+            :class="[
+              'flex items-start gap-2 rounded-md border p-3 text-sm',
+              eligibility.is_eligible ? 'border-success-br bg-success-bg text-success' : 'border-warning-br bg-warning-bg text-warning',
+            ]"
+          >
+            <CheckCircle2 v-if="eligibility.is_eligible" class="mt-0.5 h-4 w-4 flex-none" />
+            <XCircle v-else class="mt-0.5 h-4 w-4 flex-none" />
+            <span v-if="eligibility.is_eligible">Familia elegible para una nueva entrega.</span>
+            <span v-else>
+              Cobertura vigente: faltan {{ eligibility.days_remaining ?? '—' }} día(s) para una nueva entrega (RN-02).
+            </span>
+          </div>
+
+          <!-- Excepción (solo COORD) -->
+          <div v-if="eligibility && !eligibility.is_eligible">
+            <div v-if="isCoord">
+              <label class="flex cursor-pointer items-center gap-2 text-sm text-neutral-700">
+                <input v-model="exceptionMode" type="checkbox" class="h-4 w-4 accent-primary-600" />
+                <ShieldAlert class="h-4 w-4 text-warning" /> Autorizar entrega anticipada (excepción, HU-23 CA5)
+              </label>
+              <FormField v-if="exceptionMode" label="Justificación de la excepción" required :error="errors.exception" input-id="dv-exc" class="mt-2">
+                <textarea id="dv-exc" v-model="exceptionReason" rows="2" class="control" placeholder="Motivo de la entrega anticipada…" />
+              </FormField>
+            </div>
+            <p v-else class="text-xs text-neutral-500">Solo un Coordinador de logística puede autorizar una entrega anticipada.</p>
+          </div>
+        </div>
+      </fieldset>
+
+      <!-- 2. Bodega + cobertura -->
+      <fieldset class="space-y-4 rounded-lg border border-neutral-200 bg-white p-5">
+        <legend class="px-1 text-sm font-semibold text-neutral-700">2 · Origen y cobertura</legend>
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <SelectField v-model="warehouseId" label="Bodega de origen" required :options="warehouseOptions" :error="errors.warehouse" input-id="dv-wh" />
+          <FormField label="Días de cobertura" required :error="errors.coverage" input-id="dv-cov" :hint="`Mínimo ${MIN_COVERAGE_DAYS} días (RN-01).`">
+            <input id="dv-cov" v-model="coverageDays" type="number" :min="MIN_COVERAGE_DAYS" class="control" />
+          </FormField>
+        </div>
+        <p v-if="selectedFamily" class="text-xs text-neutral-500">
+          Alimento mínimo sugerido: <strong>{{ Math.round(suggestedFoodKg).toLocaleString('es-CO') }} kg</strong>
+          ({{ FOOD_KG_PER_PERSON_DAY }} kg × {{ selectedFamily.num_members }} pers × {{ Number(coverageDays) || 0 }} días).
+        </p>
+      </fieldset>
+
+      <!-- 3. Ítems -->
+      <fieldset class="space-y-3 rounded-lg border border-neutral-200 bg-white p-5">
+        <legend class="px-1 text-sm font-semibold text-neutral-700">3 · Ítems entregados</legend>
+        <div
+          v-for="(it, i) in items"
+          :key="i"
+          class="grid grid-cols-1 gap-3 rounded-md border border-neutral-200 p-3 sm:grid-cols-[2fr_1fr_1fr_auto]"
+        >
+          <SelectField v-model="it.resource_type_id" :options="resourceOptions" />
+          <FormField label="" input-id=""><input v-model="it.quantity" type="number" min="1" class="control" placeholder="Cantidad" /></FormField>
+          <FormField label="" input-id=""><input v-model="it.batch" class="control" placeholder="Lote (opc.)" /></FormField>
+          <div class="flex items-center justify-end">
+            <AppButton type="button" variant="ghost" size="sm" class="text-danger" :disabled="items.length === 1" @click="removeItem(i)"><Trash2 /></AppButton>
+          </div>
+        </div>
+        <p v-if="errors.details" class="text-sm text-danger">{{ errors.details }}</p>
+        <AppButton type="button" variant="outline" size="sm" @click="addItem"><Plus /> Agregar ítem</AppButton>
+      </fieldset>
+
+      <!-- 4. Confirmación -->
+      <fieldset class="space-y-4 rounded-lg border border-neutral-200 bg-white p-5">
+        <legend class="px-1 text-sm font-semibold text-neutral-700">4 · Recepción y ubicación</legend>
+        <FormField label="Recibido por (documento)" input-id="dv-rec" hint="Opcional">
+          <input id="dv-rec" v-model="receivedBy" class="control" placeholder="Documento de quien recibe" />
+        </FormField>
+        <FormField label="Notas" input-id="dv-notes" hint="Opcional">
+          <input id="dv-notes" v-model="notes" class="control" placeholder="Observaciones…" />
+        </FormField>
+        <FormField label="Ubicación de entrega" hint="Opcional. Toca el mapa para registrar dónde se entregó.">
+          <MapPicker v-model:latitude="latitude" v-model:longitude="longitude" height="220px" />
+        </FormField>
+      </fieldset>
+
+      <div class="flex items-center justify-end gap-3 pb-4">
+        <AppButton variant="ghost" type="button" @click="router.push('/deliveries')">Cancelar</AppButton>
+        <AppButton type="submit" :disabled="saving || blockedByCoverage">
+          <Save /> {{ saving ? 'Registrando…' : exceptionMode ? 'Registrar con excepción' : 'Registrar entrega' }}
+        </AppButton>
+      </div>
+      <p v-if="blockedByCoverage" class="-mt-2 pb-4 text-right text-xs text-warning">
+        La familia tiene cobertura vigente. {{ isCoord ? 'Autoriza una excepción para continuar.' : 'No es posible registrar la entrega.' }}
+      </p>
+    </form>
+  </section>
+</template>

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -141,11 +141,34 @@ const router = createRouter({
           component: () => import('@/pages/donations/DonationFormPage.vue'),
           meta: { roles: ['ADMIN', 'COORDINADOR_LOGISTICA', 'REGISTRADOR_DONACIONES'] },
         },
+        // Entregas (HU-22/23/12). Rutas estáticas antes de :id.
+        {
+          path: 'deliveries',
+          name: 'deliveries',
+          component: () => import('@/pages/deliveries/DeliveriesListPage.vue'),
+        },
+        {
+          path: 'deliveries/new',
+          name: 'delivery-new',
+          component: () => import('@/pages/deliveries/DeliveryFormPage.vue'),
+          meta: { roles: ['ADMIN', 'COORDINADOR_LOGISTICA', 'OPERADOR_ENTREGAS'] },
+        },
+        {
+          path: 'deliveries/batch',
+          name: 'delivery-batch',
+          component: () => import('@/pages/deliveries/DeliveryBatchPage.vue'),
+          meta: { roles: ['ADMIN', 'COORDINADOR_LOGISTICA'] },
+        },
         // Priorización (HU-08): ranking + editor de pesos del puntaje.
         {
           path: 'deliveries/ranking',
           name: 'ranking',
           component: () => import('@/pages/deliveries/RankingPage.vue'),
+        },
+        {
+          path: 'deliveries/:id',
+          name: 'delivery-detail',
+          component: () => import('@/pages/deliveries/DeliveryDetailPage.vue'),
         },
         {
           path: 'settings/scoring',

--- a/client/src/types/delivery.types.ts
+++ b/client/src/types/delivery.types.ts
@@ -1,5 +1,5 @@
-// Tipos del módulo de entregas. Por ahora solo lo necesario para el historial de
-// entregas de una familia (HU-08); el módulo de Entregas (paso 9) lo ampliará.
+// Tipos del módulo de entregas (HU-22/23/12).
+import type { Family, FamilyStatus } from './family.types'
 
 export type DeliveryStatus = 'PROGRAMADA' | 'EN_CURSO' | 'ENTREGADA'
 
@@ -15,6 +15,12 @@ export const DELIVERY_STATUS_COLOR: Record<DeliveryStatus, 'slate' | 'blue' | 'g
   EN_CURSO: 'blue',
   ENTREGADA: 'green',
 }
+
+export const DELIVERY_STATUS_OPTIONS: { value: DeliveryStatus; label: string }[] = [
+  { value: 'PROGRAMADA', label: 'Programada' },
+  { value: 'EN_CURSO', label: 'En curso' },
+  { value: 'ENTREGADA', label: 'Entregada' },
+]
 
 export interface DeliveryDetail {
   id: number
@@ -45,5 +51,85 @@ export interface Delivery {
   notes: string | null
   created_at: string
   updated_at: string
+  // El backend incluye los detalles en list/getById/by-family.
   details?: DeliveryDetail[]
+}
+
+export interface DeliveryEnriched extends Delivery {
+  family?: Pick<Family, 'id' | 'family_code' | 'head_document' | 'zone_id'> & { status?: FamilyStatus }
+  warehouse?: { id: number; name: string }
+}
+
+// Elegibilidad (RN-02, HU-23). Igual forma que /families/:id/eligibility.
+export interface DeliveryEligibility {
+  is_eligible: boolean
+  reason: string
+  last_delivery_at: string | null
+  coverage_expires: string | null
+  days_remaining: number | null
+  next_eligible_at: string | null
+}
+
+export interface DeliveryDetailInput {
+  resource_type_id: number
+  quantity: number
+  batch?: string | null
+}
+
+// POST /deliveries (entrega regular). client_op_id habilita idempotencia offline.
+export interface DeliveryPayload {
+  family_id: number
+  source_warehouse_id: number
+  coverage_days: number
+  received_by_document?: string | null
+  delivery_latitude?: number | null
+  delivery_longitude?: number | null
+  notes?: string | null
+  client_op_id?: string | null
+  details: DeliveryDetailInput[]
+}
+
+// POST /deliveries/exception (solo COORDINADOR_LOGISTICA). Requiere
+// exception_reason + exception_authorized_by (id del coordinador).
+export interface ExceptionPayload {
+  family_id: number
+  source_warehouse_id: number
+  coverage_days: number
+  exception_reason: string
+  exception_authorized_by: number
+  received_by_document?: string | null
+  delivery_latitude?: number | null
+  delivery_longitude?: number | null
+  notes?: string | null
+  details: DeliveryDetailInput[]
+}
+
+export interface DeliveryListParams {
+  page: number
+  limit: number
+  family_id?: number
+  warehouse_id?: number
+  status?: DeliveryStatus
+  date_from?: string
+  date_to?: string
+}
+
+// GET /prioritization/next-batch?count=N — vista previa del lote.
+export interface NextBatchRow {
+  id: number
+  family_code: string
+  head_document: string
+  zone_id: number
+  zone_name: string
+  shelter_id: number | null
+  num_members: number
+  priority_score: number
+  status: FamilyStatus
+  last_delivery_date: string | null
+  eligibility: { is_eligible: boolean; reason: string; next_eligible_at: string | null }
+}
+
+export interface BatchResult {
+  created: number
+  deliveries?: Delivery[]
 }


### PR DESCRIPTION
## Paso 9 del frontend (Vue): Entregas

- **DeliveriesListPage** (`/deliveries`): lista con filtros (estado, bodega, rango de fechas) + paginación; accesos a crear y a lote.
- **DeliveryFormPage** (`/deliveries/new`, HU-22/23): búsqueda de familia → **chequeo de elegibilidad** (RN-02); bodega de origen; ítems dinámicos; cobertura **≥3 días** (RN-01) con sugerencia de alimento (0,6 kg/pers/día); recepción y ubicación. **Excepción** (HU-23 CA5): solo COORDINADOR puede autorizar entrega anticipada con justificación. `Idempotency-Key` para offline.
- **DeliveryBatchPage** (`/deliveries/batch`): vista previa top-N (`/prioritization/next-batch`) con elegibilidad + **crear lote** (`POST /deliveries/batch {count}`).
- **DeliveryDetailPage** (`/deliveries/:id`): detalle, ítems, **transición de estado** (PROGRAMADA→EN_CURSO→ENTREGADA) y mini-mapa.

### Notas de contrato
- `POST /deliveries/batch` recibe solo `{count}` (crea las top-N priorizadas).
- `POST /deliveries/exception` (solo COORD) requiere `exception_reason` + `exception_authorized_by`.
- `POST /deliveries` valida elegibilidad (409 si hay cobertura vigente).

✅ `pnpm -C client typecheck` y `build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)