### PR TITLE
feat(client): Planes de Distribución (Paso 10) — HU-21

### DIFF
--- a/client/src/api/distributionPlans.api.ts
+++ b/client/src/api/distributionPlans.api.ts
@@ -1,0 +1,33 @@
+import { api } from './axios'
+import type { ApiItem, ApiList } from '@/types/api.types'
+import type {
+  CreatePlanPayload,
+  DistributionPlan,
+  DistributionPlanWithItems,
+  PlanListParams,
+} from '@/types/distributionPlan.types'
+
+export const distributionPlansApi = {
+  list(params: PlanListParams) {
+    const query: Record<string, string | number> = { page: params.page, limit: params.limit }
+    if (params.status) query.status = params.status
+    if (params.scope) query.scope = params.scope
+    return api.get<ApiList<DistributionPlanWithItems>>('/distribution-plans', { params: query }).then((r) => r.data)
+  },
+
+  getById(id: number) {
+    return api.get<ApiItem<DistributionPlanWithItems>>(`/distribution-plans/${id}`).then((r) => r.data.data)
+  },
+
+  create(payload: CreatePlanPayload) {
+    return api.post<ApiItem<DistributionPlan>>('/distribution-plans', payload).then((r) => r.data.data)
+  },
+
+  execute(id: number) {
+    return api.post<ApiItem<DistributionPlan>>(`/distribution-plans/${id}/execute`).then((r) => r.data.data)
+  },
+
+  cancel(id: number) {
+    return api.put<ApiItem<DistributionPlan>>(`/distribution-plans/${id}/cancel`).then((r) => r.data.data)
+  },
+}

--- a/client/src/components/layout/AppSidebar.vue
+++ b/client/src/components/layout/AppSidebar.vue
@@ -18,6 +18,7 @@ import {
   HeartHandshake,
   Gift,
   ListOrdered,
+  ClipboardList,
   Activity,
   BarChart3,
   Settings,
@@ -74,6 +75,7 @@ const groups: NavGroup[] = [
     items: [
       { label: 'Entregas', to: '/deliveries', icon: Truck },
       { label: 'Ranking', to: '/deliveries/ranking', icon: ListOrdered },
+      { label: 'Planes', to: '/distribution-plans', icon: ClipboardList, roles: ['ADMIN', 'COORDINADOR_LOGISTICA'] },
       { label: 'Donantes', to: '/donors', icon: HeartHandshake, roles: ['ADMIN', 'COORDINADOR_LOGISTICA', 'REGISTRADOR_DONACIONES', 'FUNCIONARIO_CONTROL'] },
       { label: 'Donaciones', to: '/donations', icon: Gift, roles: ['ADMIN', 'COORDINADOR_LOGISTICA', 'REGISTRADOR_DONACIONES', 'FUNCIONARIO_CONTROL'] },
     ],

--- a/client/src/composables/useDistributionPlans.ts
+++ b/client/src/composables/useDistributionPlans.ts
@@ -1,0 +1,42 @@
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/vue-query'
+import { computed, type Ref } from 'vue'
+import { distributionPlansApi } from '@/api/distributionPlans.api'
+import type { CreatePlanPayload, PlanListParams } from '@/types/distributionPlan.types'
+
+export function usePlansList(params: Ref<PlanListParams>) {
+  return useQuery({
+    queryKey: ['distribution-plans', 'list', params],
+    queryFn: () => distributionPlansApi.list(params.value),
+    placeholderData: keepPreviousData,
+  })
+}
+
+export function usePlan(id: Ref<number>) {
+  return useQuery({
+    queryKey: ['distribution-plans', 'detail', id],
+    queryFn: () => distributionPlansApi.getById(id.value),
+    enabled: computed(() => id.value > 0),
+  })
+}
+
+// Ejecutar un plan materializa entregas → invalida planes, entregas, inventario,
+// bodegas y priorización.
+export function usePlanMutations() {
+  const qc = useQueryClient()
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: ['distribution-plans'] })
+    qc.invalidateQueries({ queryKey: ['deliveries'] })
+    qc.invalidateQueries({ queryKey: ['warehouses'] })
+    qc.invalidateQueries({ queryKey: ['inventory'] })
+    qc.invalidateQueries({ queryKey: ['prioritization'] })
+  }
+
+  const create = useMutation({
+    mutationFn: (payload: CreatePlanPayload) => distributionPlansApi.create(payload),
+    onSuccess: invalidate,
+  })
+  const execute = useMutation({ mutationFn: distributionPlansApi.execute, onSuccess: invalidate })
+  const cancel = useMutation({ mutationFn: distributionPlansApi.cancel, onSuccess: invalidate })
+
+  return { create, execute, cancel }
+}

--- a/client/src/pages/distributionPlans/DistributionPlanDetailPage.vue
+++ b/client/src/pages/distributionPlans/DistributionPlanDetailPage.vue
@@ -1,0 +1,146 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { toast } from 'vue-sonner'
+import { ArrowLeft, PlayCircle, Ban, RotateCcw } from '@lucide/vue'
+import { usePlan, usePlanMutations } from '@/composables/useDistributionPlans'
+import {
+  PLAN_STATUS_LABELS, PLAN_SCOPE_LABELS, PLAN_ITEM_STATUS_LABELS,
+} from '@/types/distributionPlan.types'
+import type { DistributionPlanItem, DistributionPlanItemStatus } from '@/types/distributionPlan.types'
+import { apiErrorMessage } from '@/utils/apiError'
+import PageHeader from '@/components/ui/PageHeader.vue'
+import AppButton from '@/components/ui/AppButton.vue'
+import DataTable from '@/components/ui/DataTable.vue'
+import SkeletonBlock from '@/components/ui/SkeletonBlock.vue'
+import ConfirmDialog from '@/components/ui/ConfirmDialog.vue'
+import RoleGate from '@/components/auth/RoleGate.vue'
+
+const route = useRoute()
+const router = useRouter()
+const planId = computed(() => Number(route.params.id))
+const EDIT_ROLES = ['ADMIN', 'COORDINADOR_LOGISTICA'] as const
+
+const { data: plan, isLoading, isError, refetch } = usePlan(planId)
+const { execute, cancel } = usePlanMutations()
+
+const ITEM_BADGE: Record<DistributionPlanItemStatus, string> = {
+  PENDIENTE: 'bg-neutral-100 text-neutral-600',
+  ENTREGADO: 'bg-success-bg text-success',
+  SIN_ATENDER: 'bg-warning-bg text-warning',
+}
+const counters = computed(() => [
+  { label: 'Total', value: plan.value?.items_total ?? plan.value?.items?.length ?? 0, tone: 'text-neutral-900' },
+  { label: 'Pendientes', value: plan.value?.items_pendientes ?? 0, tone: 'text-primary-700' },
+  { label: 'Entregadas', value: plan.value?.items_entregados ?? 0, tone: 'text-success' },
+  { label: 'Sin atender', value: plan.value?.items_sin_atender ?? 0, tone: 'text-warning' },
+])
+
+const columns = [
+  { key: 'family_id', label: 'Familia', mono: true },
+  { key: 'target_coverage_days', label: 'Cobertura', align: 'center' as const },
+  { key: 'priority_score_snapshot', label: 'Puntaje', align: 'right' as const },
+  { key: 'status', label: 'Estado' },
+  { key: 'reason', label: 'Motivo' },
+]
+const asItem = (r: unknown) => r as DistributionPlanItem
+
+function fmtDate(s: string) {
+  return new Date(s).toLocaleDateString('es-CO', { day: '2-digit', month: 'short', year: 'numeric' })
+}
+
+const confirmKind = ref<'execute' | 'cancel' | null>(null)
+async function doConfirm() {
+  const kind = confirmKind.value
+  confirmKind.value = null
+  if (!kind) return
+  try {
+    if (kind === 'execute') {
+      await execute.mutateAsync(planId.value)
+      toast.success('Plan ejecutado: entregas generadas')
+    } else {
+      await cancel.mutateAsync(planId.value)
+      toast.success('Plan cancelado')
+    }
+  } catch (e) {
+    toast.error(apiErrorMessage(e))
+  }
+}
+</script>
+
+<template>
+  <section class="space-y-5">
+    <div v-if="isLoading" class="space-y-4"><SkeletonBlock height="120px" /><SkeletonBlock height="180px" /></div>
+    <div v-else-if="isError || !plan" class="rounded-lg border border-danger-br bg-danger-bg p-6 text-center">
+      <p class="text-sm text-danger">No se pudo cargar el plan.</p>
+      <AppButton variant="outline" size="sm" class="mt-3" @click="() => refetch()"><RotateCcw /> Reintentar</AppButton>
+    </div>
+
+    <template v-else>
+      <PageHeader :title="plan.plan_code" :crumb="`Planes · ${PLAN_SCOPE_LABELS[plan.scope]}`">
+        <template #actions>
+          <AppButton variant="outline" @click="router.push('/distribution-plans')"><ArrowLeft /> Volver</AppButton>
+          <RoleGate :roles="[...EDIT_ROLES]">
+            <AppButton v-if="plan.status === 'PROGRAMADA'" :disabled="execute.isPending.value" @click="confirmKind = 'execute'">
+              <PlayCircle /> Ejecutar
+            </AppButton>
+            <AppButton
+              v-if="plan.status === 'PROGRAMADA' || plan.status === 'EN_EJECUCION'"
+              variant="ghost"
+              class="text-danger"
+              :disabled="cancel.isPending.value"
+              @click="confirmKind = 'cancel'"
+            >
+              <Ban /> Cancelar
+            </AppButton>
+          </RoleGate>
+        </template>
+      </PageHeader>
+
+      <div class="rounded-lg border border-neutral-200 bg-white p-5">
+        <div class="flex flex-wrap items-center gap-3 text-sm text-neutral-600">
+          <span class="rounded-full bg-info-bg px-2.5 py-1 text-xs font-semibold text-primary-700">{{ PLAN_STATUS_LABELS[plan.status] }}</span>
+          <span>{{ PLAN_SCOPE_LABELS[plan.scope] }}</span>
+          <span>· Creado {{ fmtDate(plan.created_at) }}</span>
+        </div>
+        <p v-if="plan.notes" class="mt-3 rounded-md bg-neutral-50 p-3 text-sm text-neutral-600">{{ plan.notes }}</p>
+      </div>
+
+      <!-- Contadores -->
+      <div class="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <div v-for="c in counters" :key="c.label" class="rounded-lg border border-neutral-200 bg-white p-4 text-center">
+          <p :class="['text-2xl font-bold', c.tone]">{{ c.value }}</p>
+          <p class="text-xs text-neutral-500">{{ c.label }}</p>
+        </div>
+      </div>
+
+      <h2 class="text-sm font-semibold text-neutral-700">Familias del plan</h2>
+      <DataTable :columns="columns" :rows="plan.items ?? []" row-key="id" min-width="720px">
+        <template #family_id="{ row }">
+          <button class="font-semibold text-primary-700 hover:underline" @click="router.push(`/families/${asItem(row).family_id}`)">
+            #{{ asItem(row).family_id }}
+          </button>
+        </template>
+        <template #target_coverage_days="{ row }">{{ asItem(row).target_coverage_days }} días</template>
+        <template #priority_score_snapshot="{ row }"><span class="font-mono">{{ Math.round(asItem(row).priority_score_snapshot) }}</span></template>
+        <template #status="{ row }">
+          <span :class="['rounded-full px-2.5 py-1 text-xs font-semibold', ITEM_BADGE[asItem(row).status]]">{{ PLAN_ITEM_STATUS_LABELS[asItem(row).status] }}</span>
+        </template>
+        <template #reason="{ row }"><span class="text-xs text-neutral-500">{{ asItem(row).reason || '—' }}</span></template>
+        <template #empty><p class="py-6 text-center text-sm text-neutral-500">El plan no tiene familias.</p></template>
+      </DataTable>
+    </template>
+
+    <ConfirmDialog
+      :open="confirmKind !== null"
+      :tone="confirmKind === 'cancel' ? 'danger' : 'warning'"
+      :title="confirmKind === 'execute' ? 'Ejecutar plan' : 'Cancelar plan'"
+      :message="confirmKind === 'execute'
+        ? 'Se generarán las entregas programadas para las familias del plan. ¿Continuar?'
+        : 'El plan quedará cancelado y no se podrá ejecutar. ¿Continuar?'"
+      :confirm-label="confirmKind === 'execute' ? 'Ejecutar' : 'Cancelar plan'"
+      @confirm="doConfirm"
+      @close="confirmKind = null"
+    />
+  </section>
+</template>

--- a/client/src/pages/distributionPlans/DistributionPlanFormPage.vue
+++ b/client/src/pages/distributionPlans/DistributionPlanFormPage.vue
@@ -1,0 +1,140 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { toast } from 'vue-sonner'
+import { ArrowLeft, Save, Search, X } from '@lucide/vue'
+import { useZones } from '@/composables/useZones'
+import { useShelters } from '@/composables/useShelters'
+import { useFamiliesList } from '@/composables/useFamilies'
+import { usePlanMutations } from '@/composables/useDistributionPlans'
+import { PLAN_SCOPE_OPTIONS } from '@/types/distributionPlan.types'
+import type { CreatePlanPayload, DistributionPlanScope } from '@/types/distributionPlan.types'
+import type { Family, FamilyListParams } from '@/types/family.types'
+import { MIN_COVERAGE_DAYS } from '@/utils/constants'
+import { apiErrorMessage } from '@/utils/apiError'
+import PageHeader from '@/components/ui/PageHeader.vue'
+import AppButton from '@/components/ui/AppButton.vue'
+import FormField from '@/components/form/FormField.vue'
+import SelectField from '@/components/form/SelectField.vue'
+
+const router = useRouter()
+const { create } = usePlanMutations()
+const saving = computed(() => create.isPending.value)
+
+const scope = ref<DistributionPlanScope>('GLOBAL')
+const scopeId = ref('')
+const coverageDays = ref('7')
+const notes = ref('')
+const errors = ref<Record<string, string>>({})
+
+const { data: zones } = useZones()
+const { data: shelters } = useShelters()
+
+const zoneOptions = computed(() => [{ value: '', label: 'Selecciona la zona…' }, ...(zones.value ?? []).map((z) => ({ value: String(z.id), label: z.name }))])
+const shelterOptions = computed(() => [{ value: '', label: 'Selecciona el refugio…' }, ...(shelters.value ?? []).map((s) => ({ value: String(s.id), label: s.name }))])
+const scopeOptions = PLAN_SCOPE_OPTIONS.map((o) => ({ value: o.value as string, label: o.label }))
+
+// Selección de familias para scope LOTE.
+const familyQuery = ref('')
+const selectedFamilies = ref<Family[]>([])
+const searchParams = computed<FamilyListParams>(() => ({
+  page: 1,
+  limit: 8,
+  ...(familyQuery.value.trim().length >= 2 ? { q: familyQuery.value.trim() } : {}),
+}))
+const { data: familyResults } = useFamiliesList(searchParams)
+const showResults = computed(() => scope.value === 'LOTE' && familyQuery.value.trim().length >= 2)
+function addFamily(f: Family) {
+  if (!selectedFamilies.value.some((x) => x.id === f.id)) selectedFamilies.value.push(f)
+  familyQuery.value = ''
+}
+function removeFamily(id: number) {
+  selectedFamilies.value = selectedFamilies.value.filter((f) => f.id !== id)
+}
+
+function validateForm() {
+  const e: Record<string, string> = {}
+  const cd = Number(coverageDays.value)
+  if (!coverageDays.value || Number.isNaN(cd) || cd < MIN_COVERAGE_DAYS) e.coverage = `Mínimo ${MIN_COVERAGE_DAYS} días (RN-01).`
+  if ((scope.value === 'ZONA' || scope.value === 'REFUGIO') && !scopeId.value) e.scope_id = 'Selecciona el destino.'
+  if (scope.value === 'LOTE' && !selectedFamilies.value.length) e.families = 'Agrega al menos una familia.'
+  errors.value = e
+  return Object.keys(e).length === 0
+}
+
+async function submit() {
+  if (!validateForm()) return
+  const payload: CreatePlanPayload = {
+    scope: scope.value,
+    target_coverage_days: Number(coverageDays.value),
+    notes: notes.value.trim() || null,
+  }
+  if (scope.value === 'ZONA' || scope.value === 'REFUGIO') payload.scope_id = Number(scopeId.value)
+  if (scope.value === 'LOTE') payload.family_ids = selectedFamilies.value.map((f) => f.id)
+  try {
+    const plan = await create.mutateAsync(payload)
+    toast.success(`Plan ${plan.plan_code} generado`)
+    router.push(`/distribution-plans/${plan.id}`)
+  } catch (e) {
+    toast.error(apiErrorMessage(e, 'No se pudo generar el plan.'))
+  }
+}
+</script>
+
+<template>
+  <section class="mx-auto max-w-2xl space-y-5">
+    <PageHeader title="Nuevo plan de distribución" crumb="Ayudas" subtitle="Genera entregas priorizadas según el alcance (HU-21)">
+      <template #actions>
+        <AppButton variant="outline" @click="router.push('/distribution-plans')"><ArrowLeft /> Volver</AppButton>
+      </template>
+    </PageHeader>
+
+    <form class="space-y-5" @submit.prevent="submit">
+      <fieldset class="space-y-4 rounded-lg border border-neutral-200 bg-white p-5">
+        <legend class="px-1 text-sm font-semibold text-neutral-700">Alcance</legend>
+        <SelectField v-model="scope" label="Tipo de plan" required :options="scopeOptions" input-id="pl-scope" />
+
+        <SelectField v-if="scope === 'ZONA'" v-model="scopeId" label="Zona" required :options="zoneOptions" :error="errors.scope_id" input-id="pl-zone" />
+        <SelectField v-else-if="scope === 'REFUGIO'" v-model="scopeId" label="Refugio" required :options="shelterOptions" :error="errors.scope_id" input-id="pl-shelter" />
+
+        <div v-else-if="scope === 'LOTE'" class="space-y-2">
+          <FormField label="Familias del lote" required :error="errors.families" input-id="pl-fam" hint="Busca y agrega familias (mín. 2 caracteres).">
+            <div class="relative">
+              <Search class="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-neutral-400" />
+              <input id="pl-fam" v-model="familyQuery" class="control pl-9" placeholder="Código / documento / dirección" />
+            </div>
+          </FormField>
+          <ul v-if="showResults" class="max-h-48 divide-y divide-neutral-100 overflow-y-auto rounded-md border border-neutral-200">
+            <li v-for="f in (familyResults?.data ?? [])" :key="f.id">
+              <button type="button" class="flex w-full items-center justify-between px-3 py-2 text-left text-sm hover:bg-primary-50" @click="addFamily(f)">
+                <span class="font-semibold text-neutral-900">{{ f.family_code }}</span>
+                <span class="text-xs text-neutral-500">{{ f.num_members }} miembros</span>
+              </button>
+            </li>
+          </ul>
+          <div v-if="selectedFamilies.length" class="flex flex-wrap gap-2">
+            <span v-for="f in selectedFamilies" :key="f.id" class="inline-flex items-center gap-1 rounded-full bg-info-bg px-2.5 py-1 text-xs text-primary-700">
+              {{ f.family_code }}
+              <button type="button" class="hover:text-danger" @click="removeFamily(f.id)"><X class="h-3 w-3" /></button>
+            </span>
+          </div>
+        </div>
+      </fieldset>
+
+      <fieldset class="space-y-4 rounded-lg border border-neutral-200 bg-white p-5">
+        <legend class="px-1 text-sm font-semibold text-neutral-700">Parámetros</legend>
+        <FormField label="Días de cobertura por familia" required :error="errors.coverage" input-id="pl-cov" :hint="`Mínimo ${MIN_COVERAGE_DAYS} días (RN-01).`">
+          <input id="pl-cov" v-model="coverageDays" type="number" :min="MIN_COVERAGE_DAYS" class="control" />
+        </FormField>
+        <FormField label="Notas" input-id="pl-notes" hint="Opcional">
+          <textarea id="pl-notes" v-model="notes" rows="2" class="control" placeholder="Observaciones del plan…" />
+        </FormField>
+      </fieldset>
+
+      <div class="flex items-center justify-end gap-3 pb-4">
+        <AppButton variant="ghost" type="button" @click="router.push('/distribution-plans')">Cancelar</AppButton>
+        <AppButton type="submit" :disabled="saving"><Save /> {{ saving ? 'Generando…' : 'Generar plan' }}</AppButton>
+      </div>
+    </form>
+  </section>
+</template>

--- a/client/src/pages/distributionPlans/DistributionPlansListPage.vue
+++ b/client/src/pages/distributionPlans/DistributionPlansListPage.vue
@@ -1,0 +1,145 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import { Plus, Eye, SearchX, RotateCcw, ChevronLeft, ChevronRight } from '@lucide/vue'
+import { usePlansList } from '@/composables/useDistributionPlans'
+import {
+  PLAN_STATUS_OPTIONS, PLAN_STATUS_LABELS, PLAN_SCOPE_OPTIONS, PLAN_SCOPE_LABELS,
+} from '@/types/distributionPlan.types'
+import type {
+  DistributionPlanScope, DistributionPlanStatus, DistributionPlanWithItems, PlanListParams,
+} from '@/types/distributionPlan.types'
+import PageHeader from '@/components/ui/PageHeader.vue'
+import AppButton from '@/components/ui/AppButton.vue'
+import DataTable from '@/components/ui/DataTable.vue'
+import EmptyState from '@/components/ui/EmptyState.vue'
+import SkeletonBlock from '@/components/ui/SkeletonBlock.vue'
+import SelectField from '@/components/form/SelectField.vue'
+import RoleGate from '@/components/auth/RoleGate.vue'
+
+const router = useRouter()
+const PAGE_SIZE = 20
+const EDIT_ROLES = ['ADMIN', 'COORDINADOR_LOGISTICA'] as const
+
+const STATUS_BADGE: Record<DistributionPlanStatus, string> = {
+  PROGRAMADA: 'bg-neutral-100 text-neutral-600 border-neutral-200',
+  EN_EJECUCION: 'bg-info-bg text-primary-700 border-info-br',
+  COMPLETADA: 'bg-success-bg text-success border-success-br',
+  CANCELADA: 'bg-danger-bg text-danger border-danger-br',
+}
+
+const statusFilter = ref('')
+const scopeFilter = ref('')
+const page = ref(1)
+watch([statusFilter, scopeFilter], () => { page.value = 1 })
+
+const params = computed<PlanListParams>(() => ({
+  page: page.value,
+  limit: PAGE_SIZE,
+  ...(statusFilter.value ? { status: statusFilter.value as DistributionPlanStatus } : {}),
+  ...(scopeFilter.value ? { scope: scopeFilter.value as DistributionPlanScope } : {}),
+}))
+
+const { data, isLoading, isFetching, isError, refetch } = usePlansList(params)
+const rows = computed(() => data.value?.data ?? [])
+const total = computed(() => data.value?.pagination.total ?? 0)
+const totalPages = computed(() => data.value?.pagination.totalPages ?? 1)
+const rangeFrom = computed(() => (total.value === 0 ? 0 : (page.value - 1) * PAGE_SIZE + 1))
+const rangeTo = computed(() => Math.min(page.value * PAGE_SIZE, total.value))
+const hasFilters = computed(() => !!(statusFilter.value || scopeFilter.value))
+
+const statusOptions = [{ value: '', label: 'Todos los estados' }, ...PLAN_STATUS_OPTIONS.map((o) => ({ value: o.value as string, label: o.label }))]
+const scopeOptions = [{ value: '', label: 'Todos los alcances' }, ...PLAN_SCOPE_OPTIONS.map((o) => ({ value: o.value as string, label: o.label }))]
+
+const columns = [
+  { key: 'plan_code', label: 'Código', mono: true },
+  { key: 'scope', label: 'Alcance' },
+  { key: 'created_at', label: 'Creado' },
+  { key: 'status', label: 'Estado' },
+  { key: 'progress', label: 'Avance', align: 'center' as const },
+  { key: 'actions', label: '', align: 'right' as const },
+]
+const asPlan = (r: unknown) => r as DistributionPlanWithItems
+
+function fmtDate(s: string) {
+  return new Date(s).toLocaleDateString('es-CO', { day: '2-digit', month: 'short', year: 'numeric' })
+}
+function goTo(p: number) { page.value = Math.min(Math.max(1, p), totalPages.value) }
+function clearFilters() { statusFilter.value = ''; scopeFilter.value = '' }
+</script>
+
+<template>
+  <section class="space-y-5">
+    <PageHeader
+      title="Planes de distribución"
+      crumb="Ayudas"
+      :subtitle="total ? `${total} ${total === 1 ? 'plan' : 'planes'}` : 'Generación priorizada de entregas (HU-21)'"
+    >
+      <template #actions>
+        <RoleGate :roles="[...EDIT_ROLES]">
+          <AppButton @click="router.push('/distribution-plans/new')"><Plus /> Nuevo plan</AppButton>
+        </RoleGate>
+      </template>
+    </PageHeader>
+
+    <div class="grid grid-cols-1 gap-3 rounded-lg border border-neutral-200 bg-white p-4 sm:grid-cols-2">
+      <SelectField v-model="statusFilter" :options="statusOptions" />
+      <SelectField v-model="scopeFilter" :options="scopeOptions" />
+    </div>
+
+    <div v-if="isError" class="rounded-lg border border-danger-br bg-danger-bg p-6 text-center">
+      <p class="text-sm text-danger">No se pudieron cargar los planes.</p>
+      <AppButton variant="outline" size="sm" class="mt-3" @click="() => refetch()"><RotateCcw /> Reintentar</AppButton>
+    </div>
+    <div v-else-if="isLoading" class="space-y-2 rounded-lg border border-neutral-200 bg-white p-4">
+      <SkeletonBlock v-for="n in 6" :key="n" height="44px" />
+    </div>
+
+    <template v-else>
+      <div :class="{ 'opacity-60 transition-opacity': isFetching }">
+        <DataTable :columns="columns" :rows="rows" row-key="id" min-width="820px">
+          <template #plan_code="{ row }"><span class="font-semibold text-neutral-900">{{ asPlan(row).plan_code }}</span></template>
+          <template #scope="{ row }">{{ PLAN_SCOPE_LABELS[asPlan(row).scope] }}</template>
+          <template #created_at="{ row }">{{ fmtDate(asPlan(row).created_at) }}</template>
+          <template #status="{ row }">
+            <span :class="['inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-semibold', STATUS_BADGE[asPlan(row).status]]">
+              {{ PLAN_STATUS_LABELS[asPlan(row).status] }}
+            </span>
+          </template>
+          <template #progress="{ row }">
+            <span class="font-mono text-xs">{{ asPlan(row).items_entregados ?? 0 }}/{{ asPlan(row).items_total ?? 0 }}</span>
+            <span v-if="(asPlan(row).items_sin_atender ?? 0) > 0" class="ml-2 text-xs font-semibold text-warning">
+              {{ asPlan(row).items_sin_atender }} sin atender
+            </span>
+          </template>
+          <template #actions="{ row }">
+            <AppButton variant="ghost" size="sm" @click="router.push(`/distribution-plans/${asPlan(row).id}`)"><Eye /> Ver</AppButton>
+          </template>
+          <template #empty>
+            <EmptyState
+              title="Sin planes"
+              :message="hasFilters ? 'No hay planes que coincidan con los filtros.' : 'Aún no se han generado planes de distribución.'"
+            >
+              <template #icon><SearchX /></template>
+              <template #action>
+                <AppButton v-if="hasFilters" variant="outline" size="sm" @click="clearFilters"><RotateCcw /> Limpiar filtros</AppButton>
+                <RoleGate v-else :roles="[...EDIT_ROLES]">
+                  <AppButton size="sm" @click="router.push('/distribution-plans/new')"><Plus /> Nuevo plan</AppButton>
+                </RoleGate>
+              </template>
+            </EmptyState>
+          </template>
+        </DataTable>
+      </div>
+
+      <div v-if="total > 0" class="flex flex-wrap items-center justify-between gap-3 text-sm text-neutral-600">
+        <span>Mostrando <strong>{{ rangeFrom }}–{{ rangeTo }}</strong> de <strong>{{ total }}</strong></span>
+        <div class="flex items-center gap-2">
+          <AppButton variant="outline" size="sm" :disabled="page <= 1" @click="goTo(page - 1)"><ChevronLeft /></AppButton>
+          <span class="px-1">Página {{ page }} de {{ totalPages }}</span>
+          <AppButton variant="outline" size="sm" :disabled="page >= totalPages" @click="goTo(page + 1)"><ChevronRight /></AppButton>
+        </div>
+      </div>
+    </template>
+  </section>
+</template>

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -176,7 +176,26 @@ const router = createRouter({
           component: () => import('@/pages/settings/ScoringConfigPage.vue'),
           meta: { roles: ['ADMIN', 'COORDINADOR_LOGISTICA'] },
         },
-        // Las demas rutas (entregas, mapa, etc.) se agregan aqui
+        // Planes de distribución (HU-21).
+        {
+          path: 'distribution-plans',
+          name: 'distribution-plans',
+          component: () => import('@/pages/distributionPlans/DistributionPlansListPage.vue'),
+          meta: { roles: ['ADMIN', 'COORDINADOR_LOGISTICA'] },
+        },
+        {
+          path: 'distribution-plans/new',
+          name: 'distribution-plan-new',
+          component: () => import('@/pages/distributionPlans/DistributionPlanFormPage.vue'),
+          meta: { roles: ['ADMIN', 'COORDINADOR_LOGISTICA'] },
+        },
+        {
+          path: 'distribution-plans/:id',
+          name: 'distribution-plan-detail',
+          component: () => import('@/pages/distributionPlans/DistributionPlanDetailPage.vue'),
+          meta: { roles: ['ADMIN', 'COORDINADOR_LOGISTICA'] },
+        },
+        // Las demas rutas (mapa, etc.) se agregan aqui
         // a medida que se implementan las HU. Ver HistoriasDeUsuario.json.
       ],
     },

--- a/client/src/types/distributionPlan.types.ts
+++ b/client/src/types/distributionPlan.types.ts
@@ -1,0 +1,79 @@
+// Tipos del módulo de planes de distribución (HU-21).
+
+export type DistributionPlanStatus = 'PROGRAMADA' | 'EN_EJECUCION' | 'COMPLETADA' | 'CANCELADA'
+export type DistributionPlanScope = 'GLOBAL' | 'ZONA' | 'REFUGIO' | 'LOTE'
+export type DistributionPlanItemStatus = 'PENDIENTE' | 'ENTREGADO' | 'SIN_ATENDER'
+
+export const PLAN_STATUS_LABELS: Record<DistributionPlanStatus, string> = {
+  PROGRAMADA: 'Programada',
+  EN_EJECUCION: 'En ejecución',
+  COMPLETADA: 'Completada',
+  CANCELADA: 'Cancelada',
+}
+
+export const PLAN_SCOPE_OPTIONS: { value: DistributionPlanScope; label: string }[] = [
+  { value: 'GLOBAL', label: 'Global (todas las familias)' },
+  { value: 'ZONA', label: 'Por zona' },
+  { value: 'REFUGIO', label: 'Por refugio' },
+  { value: 'LOTE', label: 'Lote (familias específicas)' },
+]
+export const PLAN_SCOPE_LABELS = Object.fromEntries(
+  PLAN_SCOPE_OPTIONS.map((o) => [o.value, o.label]),
+) as Record<DistributionPlanScope, string>
+
+export const PLAN_ITEM_STATUS_LABELS: Record<DistributionPlanItemStatus, string> = {
+  PENDIENTE: 'Pendiente',
+  ENTREGADO: 'Entregado',
+  SIN_ATENDER: 'Sin atender',
+}
+
+export const PLAN_STATUS_OPTIONS = (Object.keys(PLAN_STATUS_LABELS) as DistributionPlanStatus[]).map(
+  (value) => ({ value, label: PLAN_STATUS_LABELS[value] }),
+)
+
+export interface DistributionPlan {
+  id: number
+  plan_code: string
+  created_by: number
+  status: DistributionPlanStatus
+  scope: DistributionPlanScope
+  scope_id: number | null
+  notes: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface DistributionPlanItem {
+  id: number
+  plan_id: number
+  family_id: number
+  source_warehouse_id: number | null
+  target_coverage_days: number
+  priority_score_snapshot: number
+  status: DistributionPlanItemStatus
+  delivery_id: number | null
+  reason: string | null
+}
+
+export interface DistributionPlanWithItems extends DistributionPlan {
+  items?: DistributionPlanItem[]
+  items_total?: number
+  items_pendientes?: number
+  items_entregados?: number
+  items_sin_atender?: number
+}
+
+export interface PlanListParams {
+  page: number
+  limit: number
+  status?: DistributionPlanStatus
+  scope?: DistributionPlanScope
+}
+
+export interface CreatePlanPayload {
+  scope: DistributionPlanScope
+  target_coverage_days: number
+  scope_id?: number | null
+  family_ids?: number[]
+  notes?: string | null
+}


### PR DESCRIPTION
Lista + wizard (scope GLOBAL/ZONA/REFUGIO/LOTE) + detalle con contadores (incl. **sin atender**, HU-21 CA4) y acciones Ejecutar/Cancelar. POST crea el plan con items (sin endpoint de preview). ✅ typecheck y build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)