### PR TITLE
feat(client): Vectores sanitarios + Traslados (Paso 11) — HU-24/25/26

### DIFF
--- a/client/src/api/healthVectors.api.ts
+++ b/client/src/api/healthVectors.api.ts
@@ -1,0 +1,34 @@
+import { api } from './axios'
+import type { ApiItem, ApiList } from '@/types/api.types'
+import type {
+  HealthVector, HealthVectorEnriched, HealthVectorListParams, HealthVectorPayload, HealthVectorStatus,
+} from '@/types/healthVector.types'
+
+export const healthVectorsApi = {
+  list(params: HealthVectorListParams) {
+    const query: Record<string, string | number> = { page: params.page, limit: params.limit }
+    if (params.zone_id) query.zone_id = params.zone_id
+    if (params.status) query.status = params.status
+    if (params.risk_level) query.risk_level = params.risk_level
+    if (params.vector_type) query.vector_type = params.vector_type
+    return api.get<ApiList<HealthVectorEnriched>>('/health-vectors', { params: query }).then((r) => r.data)
+  },
+
+  create(payload: HealthVectorPayload) {
+    return api.post<ApiItem<HealthVector>>('/health-vectors', payload).then((r) => r.data.data)
+  },
+
+  update(id: number, payload: Partial<HealthVectorPayload> & { actions_taken?: string | null }) {
+    return api.put<ApiItem<HealthVector>>(`/health-vectors/${id}`, payload).then((r) => r.data.data)
+  },
+
+  setStatus(id: number, status: HealthVectorStatus, actions_taken?: string | null) {
+    return api
+      .put<ApiItem<HealthVector>>(`/health-vectors/${id}/status`, { status, ...(actions_taken ? { actions_taken } : {}) })
+      .then((r) => r.data.data)
+  },
+
+  remove(id: number) {
+    return api.delete(`/health-vectors/${id}`).then(() => undefined)
+  },
+}

--- a/client/src/api/relocations.api.ts
+++ b/client/src/api/relocations.api.ts
@@ -1,0 +1,19 @@
+import { api } from './axios'
+import type { ApiItem, ApiList } from '@/types/api.types'
+import type { RelocationEnriched, RelocationListParams, RelocationPayload } from '@/types/relocation.types'
+
+export const relocationsApi = {
+  list(params: RelocationListParams) {
+    const query: Record<string, string | number> = { page: params.page, limit: params.limit }
+    if (params.family_id) query.family_id = params.family_id
+    if (params.type) query.type = params.type
+    if (params.date_from) query.date_from = params.date_from
+    if (params.date_to) query.date_to = params.date_to
+    return api.get<ApiList<RelocationEnriched>>('/relocations', { params: query }).then((r) => r.data)
+  },
+
+  // Origen y autorizado-por los deriva el backend (refugio actual + usuario).
+  create(payload: RelocationPayload) {
+    return api.post<ApiItem<RelocationEnriched>>('/relocations', payload).then((r) => r.data.data)
+  },
+}

--- a/client/src/components/layout/AppSidebar.vue
+++ b/client/src/components/layout/AppSidebar.vue
@@ -20,6 +20,7 @@ import {
   ListOrdered,
   ClipboardList,
   Activity,
+  MoveRight,
   BarChart3,
   Settings,
   SlidersHorizontal,
@@ -84,6 +85,7 @@ const groups: NavGroup[] = [
     title: 'Operaciones',
     items: [
       { label: 'Vectores', to: '/health/vectors', icon: Activity, roles: ['ADMIN', 'COORDINADOR_LOGISTICA'] },
+      { label: 'Traslados', to: '/relocations', icon: MoveRight, roles: ['ADMIN', 'COORDINADOR_LOGISTICA'] },
     ],
   },
   {

--- a/client/src/composables/useHealthVectors.ts
+++ b/client/src/composables/useHealthVectors.ts
@@ -1,0 +1,35 @@
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/vue-query'
+import type { Ref } from 'vue'
+import { healthVectorsApi } from '@/api/healthVectors.api'
+import type { HealthVectorListParams, HealthVectorPayload, HealthVectorStatus } from '@/types/healthVector.types'
+
+export function useHealthVectorsList(params: Ref<HealthVectorListParams>) {
+  return useQuery({
+    queryKey: ['health-vectors', 'list', params],
+    queryFn: () => healthVectorsApi.list(params.value),
+    placeholderData: keepPreviousData,
+  })
+}
+
+export function useHealthVectorMutations() {
+  const qc = useQueryClient()
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: ['health-vectors'] })
+    qc.invalidateQueries({ queryKey: ['map'] })
+  }
+
+  const create = useMutation({ mutationFn: healthVectorsApi.create, onSuccess: invalidate })
+  const update = useMutation({
+    mutationFn: ({ id, payload }: { id: number; payload: Partial<HealthVectorPayload> & { actions_taken?: string | null } }) =>
+      healthVectorsApi.update(id, payload),
+    onSuccess: invalidate,
+  })
+  const setStatus = useMutation({
+    mutationFn: ({ id, status, actions_taken }: { id: number; status: HealthVectorStatus; actions_taken?: string | null }) =>
+      healthVectorsApi.setStatus(id, status, actions_taken),
+    onSuccess: invalidate,
+  })
+  const remove = useMutation({ mutationFn: healthVectorsApi.remove, onSuccess: invalidate })
+
+  return { create, update, setStatus, remove }
+}

--- a/client/src/composables/useRelocations.ts
+++ b/client/src/composables/useRelocations.ts
@@ -1,0 +1,26 @@
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/vue-query'
+import type { Ref } from 'vue'
+import { relocationsApi } from '@/api/relocations.api'
+import type { RelocationListParams } from '@/types/relocation.types'
+
+export function useRelocationsList(params: Ref<RelocationListParams>) {
+  return useQuery({
+    queryKey: ['relocations', 'list', params],
+    queryFn: () => relocationsApi.list(params.value),
+    placeholderData: keepPreviousData,
+  })
+}
+
+// Un traslado cambia el refugio de la familia y la ocupación de los refugios.
+export function useRelocationMutations() {
+  const qc = useQueryClient()
+  const create = useMutation({
+    mutationFn: relocationsApi.create,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['relocations'] })
+      qc.invalidateQueries({ queryKey: ['families'] })
+      qc.invalidateQueries({ queryKey: ['shelters'] })
+    },
+  })
+  return { create }
+}

--- a/client/src/pages/health/HealthVectorsPage.vue
+++ b/client/src/pages/health/HealthVectorsPage.vue
@@ -1,0 +1,323 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { toast } from 'vue-sonner'
+import { Plus, Pencil, Trash2, Activity, RotateCcw, ChevronLeft, ChevronRight, RefreshCw } from '@lucide/vue'
+import { useHealthVectorsList, useHealthVectorMutations } from '@/composables/useHealthVectors'
+import { useZones } from '@/composables/useZones'
+import { useShelters } from '@/composables/useShelters'
+import {
+  VECTOR_TYPE_OPTIONS, VECTOR_TYPE_LABELS, VECTOR_STATUS_OPTIONS, VECTOR_STATUS_LABELS, VECTOR_STATUS_BADGE,
+} from '@/types/healthVector.types'
+import type {
+  HealthVectorEnriched, HealthVectorListParams, HealthVectorPayload, HealthVectorStatus, VectorType,
+} from '@/types/healthVector.types'
+import { RISK_LEVEL_OPTIONS } from '@/types/zone.types'
+import type { RiskLevel } from '@/types/zone.types'
+import { apiErrorMessage } from '@/utils/apiError'
+import PageHeader from '@/components/ui/PageHeader.vue'
+import AppButton from '@/components/ui/AppButton.vue'
+import DataTable from '@/components/ui/DataTable.vue'
+import EmptyState from '@/components/ui/EmptyState.vue'
+import SkeletonBlock from '@/components/ui/SkeletonBlock.vue'
+import RiskLevelBadge from '@/components/ui/RiskLevelBadge.vue'
+import BaseModal from '@/components/ui/BaseModal.vue'
+import ConfirmDialog from '@/components/ui/ConfirmDialog.vue'
+import FormField from '@/components/form/FormField.vue'
+import SelectField from '@/components/form/SelectField.vue'
+import MapPicker from '@/components/form/MapPicker.vue'
+import RoleGate from '@/components/auth/RoleGate.vue'
+
+const PAGE_SIZE = 20
+const EDIT_ROLES = ['ADMIN', 'COORDINADOR_LOGISTICA'] as const
+const DELETE_ROLES = ['ADMIN'] as const
+
+const statusFilter = ref('')
+const typeFilter = ref('')
+const riskFilter = ref('')
+const zoneFilter = ref('')
+const page = ref(1)
+
+const params = computed<HealthVectorListParams>(() => ({
+  page: page.value,
+  limit: PAGE_SIZE,
+  ...(statusFilter.value ? { status: statusFilter.value as HealthVectorStatus } : {}),
+  ...(typeFilter.value ? { vector_type: typeFilter.value as VectorType } : {}),
+  ...(riskFilter.value ? { risk_level: riskFilter.value as RiskLevel } : {}),
+  ...(zoneFilter.value ? { zone_id: Number(zoneFilter.value) } : {}),
+}))
+
+const { data, isLoading, isFetching, isError, refetch } = useHealthVectorsList(params)
+const { data: zones } = useZones()
+const { data: shelters } = useShelters()
+const { create, update, setStatus, remove } = useHealthVectorMutations()
+
+const zoneMap = computed(() => new Map((zones.value ?? []).map((z) => [z.id, z])))
+const shelterMap = computed(() => new Map((shelters.value ?? []).map((s) => [s.id, s])))
+const rows = computed(() => data.value?.data ?? [])
+const total = computed(() => data.value?.pagination.total ?? 0)
+const totalPages = computed(() => data.value?.pagination.totalPages ?? 1)
+const hasFilters = computed(() => !!(statusFilter.value || typeFilter.value || riskFilter.value || zoneFilter.value))
+
+const zoneFilterOptions = computed(() => [{ value: '', label: 'Todas las zonas' }, ...(zones.value ?? []).map((z) => ({ value: String(z.id), label: z.name }))])
+const zoneFormOptions = computed(() => [{ value: '', label: 'Sin zona' }, ...(zones.value ?? []).map((z) => ({ value: String(z.id), label: z.name }))])
+const shelterFormOptions = computed(() => [{ value: '', label: 'Sin refugio' }, ...(shelters.value ?? []).map((s) => ({ value: String(s.id), label: s.name }))])
+const typeFilterOptions = [{ value: '', label: 'Todos los tipos' }, ...VECTOR_TYPE_OPTIONS]
+const typeFormOptions = [{ value: '', label: 'Selecciona…' }, ...VECTOR_TYPE_OPTIONS]
+const statusFilterOptions = [{ value: '', label: 'Todos los estados' }, ...VECTOR_STATUS_OPTIONS]
+const riskFilterOptions = [{ value: '', label: 'Todos los riesgos' }, ...RISK_LEVEL_OPTIONS.map((o) => ({ value: o.value as string, label: o.label }))]
+const riskFormOptions = [{ value: '', label: 'Selecciona…' }, ...RISK_LEVEL_OPTIONS.map((o) => ({ value: o.value as string, label: o.label }))]
+
+const columns = [
+  { key: 'vector_type', label: 'Vector' },
+  { key: 'risk_level', label: 'Riesgo' },
+  { key: 'location', label: 'Ubicación' },
+  { key: 'status', label: 'Estado' },
+  { key: 'reported_date', label: 'Reportado' },
+  { key: 'actions', label: '', align: 'right' as const },
+]
+const asVector = (r: unknown) => r as HealthVectorEnriched
+
+function fmtDate(s: string) {
+  return new Date(s).toLocaleDateString('es-CO', { day: '2-digit', month: 'short', year: 'numeric' })
+}
+function locationOf(v: HealthVectorEnriched) {
+  if (v.shelter_id) return v.shelter?.name ?? shelterMap.value.get(v.shelter_id)?.name ?? 'Refugio'
+  if (v.zone_id) return v.zone?.name ?? zoneMap.value.get(v.zone_id)?.name ?? 'Zona'
+  return v.latitude != null ? 'Coordenadas' : '—'
+}
+function goTo(p: number) { page.value = Math.min(Math.max(1, p), totalPages.value) }
+function clearFilters() { statusFilter.value = ''; typeFilter.value = ''; riskFilter.value = ''; zoneFilter.value = '' }
+
+// --- Modal crear / editar -----------------------------------------------------
+const saving = computed(() => create.isPending.value || update.isPending.value)
+const modalOpen = ref(false)
+const editId = ref<number | null>(null)
+const errors = ref<Record<string, string>>({})
+function blankForm() {
+  return {
+    vector_type: '', risk_level: '', description: '',
+    zone_id: '', shelter_id: '', latitude: null as number | null, longitude: null as number | null,
+  }
+}
+const form = ref(blankForm())
+
+function openCreate() {
+  editId.value = null
+  form.value = blankForm()
+  errors.value = {}
+  modalOpen.value = true
+}
+function openEdit(v: HealthVectorEnriched) {
+  editId.value = v.id
+  form.value = {
+    vector_type: v.vector_type,
+    risk_level: v.risk_level,
+    description: v.description ?? '',
+    zone_id: v.zone_id != null ? String(v.zone_id) : '',
+    shelter_id: v.shelter_id != null ? String(v.shelter_id) : '',
+    latitude: v.latitude,
+    longitude: v.longitude,
+  }
+  errors.value = {}
+  modalOpen.value = true
+}
+async function submit() {
+  const e: Record<string, string> = {}
+  if (!form.value.vector_type) e.vector_type = 'Selecciona el tipo.'
+  if (!form.value.risk_level) e.risk_level = 'Selecciona el riesgo.'
+  errors.value = e
+  if (Object.keys(e).length) return
+
+  const common = {
+    risk_level: form.value.risk_level as RiskLevel,
+    description: form.value.description.trim() || null,
+    zone_id: form.value.zone_id ? Number(form.value.zone_id) : null,
+    shelter_id: form.value.shelter_id ? Number(form.value.shelter_id) : null,
+    latitude: form.value.latitude,
+    longitude: form.value.longitude,
+  }
+  try {
+    if (editId.value != null) {
+      await update.mutateAsync({ id: editId.value, payload: common })
+      toast.success('Vector actualizado')
+    } else {
+      const payload: HealthVectorPayload = {
+        ...common,
+        vector_type: form.value.vector_type as VectorType,
+        reported_date: new Date().toISOString(),
+      }
+      await create.mutateAsync(payload)
+      toast.success('Vector reportado')
+    }
+    modalOpen.value = false
+  } catch (err) {
+    toast.error(apiErrorMessage(err))
+  }
+}
+
+// --- Modal de estado ----------------------------------------------------------
+const statusModalOpen = ref(false)
+const statusTarget = ref<HealthVectorEnriched | null>(null)
+const statusValue = ref<HealthVectorStatus>('ACTIVO')
+const actionsTaken = ref('')
+const statusSaving = computed(() => setStatus.isPending.value)
+function openStatus(v: HealthVectorEnriched) {
+  statusTarget.value = v
+  statusValue.value = v.status
+  actionsTaken.value = v.actions_taken ?? ''
+  statusModalOpen.value = true
+}
+async function saveStatus() {
+  if (!statusTarget.value) return
+  try {
+    await setStatus.mutateAsync({ id: statusTarget.value.id, status: statusValue.value, actions_taken: actionsTaken.value.trim() || null })
+    toast.success('Estado actualizado')
+    statusModalOpen.value = false
+  } catch (e) {
+    toast.error(apiErrorMessage(e))
+  }
+}
+
+// --- Eliminar -----------------------------------------------------------------
+const confirmOpen = ref(false)
+const target = ref<HealthVectorEnriched | null>(null)
+function askDelete(v: HealthVectorEnriched) { target.value = v; confirmOpen.value = true }
+async function confirmDelete() {
+  if (!target.value) return
+  try {
+    await remove.mutateAsync(target.value.id)
+    toast.success('Vector eliminado')
+  } catch (e) {
+    toast.error(apiErrorMessage(e))
+  } finally {
+    confirmOpen.value = false
+    target.value = null
+  }
+}
+</script>
+
+<template>
+  <section class="space-y-5">
+    <PageHeader
+      title="Vectores sanitarios"
+      crumb="Operaciones"
+      :subtitle="total ? `${total} ${total === 1 ? 'vector' : 'vectores'}` : 'Riesgos sanitarios reportados (HU-25/26)'"
+    >
+      <template #actions>
+        <RoleGate :roles="[...EDIT_ROLES]"><AppButton @click="openCreate"><Plus /> Reportar vector</AppButton></RoleGate>
+      </template>
+    </PageHeader>
+
+    <div class="grid grid-cols-1 gap-3 rounded-lg border border-neutral-200 bg-white p-4 sm:grid-cols-2 lg:grid-cols-4">
+      <SelectField v-model="statusFilter" :options="statusFilterOptions" />
+      <SelectField v-model="typeFilter" :options="typeFilterOptions" />
+      <SelectField v-model="riskFilter" :options="riskFilterOptions" />
+      <SelectField v-model="zoneFilter" :options="zoneFilterOptions" />
+    </div>
+
+    <div v-if="isError" class="rounded-lg border border-danger-br bg-danger-bg p-6 text-center">
+      <p class="text-sm text-danger">No se pudieron cargar los vectores.</p>
+      <AppButton variant="outline" size="sm" class="mt-3" @click="() => refetch()"><RotateCcw /> Reintentar</AppButton>
+    </div>
+    <div v-else-if="isLoading" class="space-y-2 rounded-lg border border-neutral-200 bg-white p-4">
+      <SkeletonBlock v-for="n in 6" :key="n" height="44px" />
+    </div>
+
+    <template v-else>
+      <div :class="{ 'opacity-60 transition-opacity': isFetching }">
+        <DataTable :columns="columns" :rows="rows" row-key="id" min-width="880px">
+          <template #vector_type="{ row }">
+            <div>
+              <p class="font-semibold text-neutral-900">{{ VECTOR_TYPE_LABELS[asVector(row).vector_type] }}</p>
+              <p v-if="asVector(row).description" class="max-w-[280px] truncate text-xs text-neutral-500">{{ asVector(row).description }}</p>
+            </div>
+          </template>
+          <template #risk_level="{ row }"><RiskLevelBadge :level="asVector(row).risk_level" /></template>
+          <template #location="{ row }">{{ locationOf(asVector(row)) }}</template>
+          <template #status="{ row }">
+            <span :class="['inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-semibold', VECTOR_STATUS_BADGE[asVector(row).status]]">
+              {{ VECTOR_STATUS_LABELS[asVector(row).status] }}
+            </span>
+          </template>
+          <template #reported_date="{ row }">{{ fmtDate(asVector(row).reported_date) }}</template>
+          <template #actions="{ row }">
+            <div class="flex justify-end gap-1">
+              <RoleGate :roles="[...EDIT_ROLES]">
+                <AppButton variant="ghost" size="sm" @click="openStatus(asVector(row))"><RefreshCw /> Estado</AppButton>
+                <AppButton variant="ghost" size="sm" @click="openEdit(asVector(row))"><Pencil /></AppButton>
+              </RoleGate>
+              <RoleGate :roles="[...DELETE_ROLES]">
+                <AppButton variant="ghost" size="sm" class="text-danger" @click="askDelete(asVector(row))"><Trash2 /></AppButton>
+              </RoleGate>
+            </div>
+          </template>
+          <template #empty>
+            <EmptyState :message="hasFilters ? 'No hay vectores que coincidan con los filtros.' : 'No hay vectores sanitarios reportados.'" title="Sin vectores">
+              <template #icon><Activity /></template>
+              <template #action>
+                <AppButton v-if="hasFilters" variant="outline" size="sm" @click="clearFilters"><RotateCcw /> Limpiar filtros</AppButton>
+                <RoleGate v-else :roles="[...EDIT_ROLES]"><AppButton size="sm" @click="openCreate"><Plus /> Reportar vector</AppButton></RoleGate>
+              </template>
+            </EmptyState>
+          </template>
+        </DataTable>
+      </div>
+
+      <div v-if="total > 0" class="flex flex-wrap items-center justify-between gap-3 text-sm text-neutral-600">
+        <span>{{ total }} en total</span>
+        <div class="flex items-center gap-2">
+          <AppButton variant="outline" size="sm" :disabled="page <= 1" @click="goTo(page - 1)"><ChevronLeft /></AppButton>
+          <span class="px-1">Página {{ page }} de {{ totalPages }}</span>
+          <AppButton variant="outline" size="sm" :disabled="page >= totalPages" @click="goTo(page + 1)"><ChevronRight /></AppButton>
+        </div>
+      </div>
+    </template>
+
+    <!-- Modal crear / editar -->
+    <BaseModal :open="modalOpen" :title="editId != null ? 'Editar vector' : 'Reportar vector'" max-width="max-w-[620px]" @close="modalOpen = false">
+      <form class="space-y-4" @submit.prevent="submit">
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <SelectField v-model="form.vector_type" label="Tipo de vector" required :options="typeFormOptions" :error="errors.vector_type" :disabled="editId != null" input-id="hv-type" />
+          <SelectField v-model="form.risk_level" label="Nivel de riesgo" required :options="riskFormOptions" :error="errors.risk_level" input-id="hv-risk" />
+        </div>
+        <FormField label="Descripción" input-id="hv-desc" hint="Opcional">
+          <textarea id="hv-desc" v-model="form.description" rows="2" class="control" placeholder="Detalle del riesgo…" />
+        </FormField>
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <SelectField v-model="form.zone_id" label="Zona" :options="zoneFormOptions" input-id="hv-zone" />
+          <SelectField v-model="form.shelter_id" label="Refugio" :options="shelterFormOptions" input-id="hv-shelter" />
+        </div>
+        <FormField label="Ubicación exacta" hint="Opcional. Toca el mapa para marcar el punto.">
+          <MapPicker v-model:latitude="form.latitude" v-model:longitude="form.longitude" height="220px" />
+        </FormField>
+      </form>
+      <template #footer>
+        <AppButton variant="ghost" @click="modalOpen = false">Cancelar</AppButton>
+        <AppButton :disabled="saving" @click="submit">{{ saving ? 'Guardando…' : editId != null ? 'Guardar' : 'Reportar' }}</AppButton>
+      </template>
+    </BaseModal>
+
+    <!-- Modal de estado -->
+    <BaseModal :open="statusModalOpen" title="Actualizar estado" max-width="max-w-[460px]" @close="statusModalOpen = false">
+      <div class="space-y-4">
+        <SelectField v-model="statusValue" label="Estado" :options="VECTOR_STATUS_OPTIONS" input-id="hv-st" />
+        <FormField label="Acciones tomadas" input-id="hv-actions" hint="Opcional">
+          <textarea id="hv-actions" v-model="actionsTaken" rows="3" class="control" placeholder="Describe las acciones realizadas…" />
+        </FormField>
+      </div>
+      <template #footer>
+        <AppButton variant="ghost" @click="statusModalOpen = false">Cancelar</AppButton>
+        <AppButton :disabled="statusSaving" @click="saveStatus">{{ statusSaving ? 'Guardando…' : 'Actualizar' }}</AppButton>
+      </template>
+    </BaseModal>
+
+    <ConfirmDialog
+      :open="confirmOpen"
+      title="Eliminar vector"
+      :message="target ? `¿Eliminar el vector “${VECTOR_TYPE_LABELS[target.vector_type]}”? Esta acción no se puede deshacer.` : ''"
+      confirm-label="Eliminar"
+      @confirm="confirmDelete"
+      @close="confirmOpen = false"
+    />
+  </section>
+</template>

--- a/client/src/pages/relocations/RelocationsPage.vue
+++ b/client/src/pages/relocations/RelocationsPage.vue
@@ -1,0 +1,229 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { toast } from 'vue-sonner'
+import { Plus, Search, MoveRight, RotateCcw, ChevronLeft, ChevronRight } from '@lucide/vue'
+import { useRelocationsList, useRelocationMutations } from '@/composables/useRelocations'
+import { useFamiliesList } from '@/composables/useFamilies'
+import { useShelters } from '@/composables/useShelters'
+import { RELOCATION_TYPE_OPTIONS, RELOCATION_TYPE_LABELS } from '@/types/relocation.types'
+import type { RelocationEnriched, RelocationListParams, RelocationPayload, RelocationType } from '@/types/relocation.types'
+import type { Family, FamilyListParams } from '@/types/family.types'
+import { apiErrorMessage } from '@/utils/apiError'
+import PageHeader from '@/components/ui/PageHeader.vue'
+import AppButton from '@/components/ui/AppButton.vue'
+import DataTable from '@/components/ui/DataTable.vue'
+import EmptyState from '@/components/ui/EmptyState.vue'
+import SkeletonBlock from '@/components/ui/SkeletonBlock.vue'
+import BaseModal from '@/components/ui/BaseModal.vue'
+import FormField from '@/components/form/FormField.vue'
+import SelectField from '@/components/form/SelectField.vue'
+import RoleGate from '@/components/auth/RoleGate.vue'
+
+const PAGE_SIZE = 20
+const EDIT_ROLES = ['ADMIN', 'COORDINADOR_LOGISTICA'] as const
+
+const typeFilter = ref('')
+const page = ref(1)
+watch(typeFilter, () => { page.value = 1 })
+
+const params = computed<RelocationListParams>(() => ({
+  page: page.value,
+  limit: PAGE_SIZE,
+  ...(typeFilter.value ? { type: typeFilter.value as RelocationType } : {}),
+}))
+
+const { data, isLoading, isFetching, isError, refetch } = useRelocationsList(params)
+const { data: shelters } = useShelters()
+const { create } = useRelocationMutations()
+
+const shelterMap = computed(() => new Map((shelters.value ?? []).map((s) => [s.id, s])))
+const rows = computed(() => data.value?.data ?? [])
+const total = computed(() => data.value?.pagination.total ?? 0)
+const totalPages = computed(() => data.value?.pagination.totalPages ?? 1)
+const hasFilters = computed(() => !!typeFilter.value)
+
+const typeFilterOptions = [{ value: '', label: 'Todos los tipos' }, ...RELOCATION_TYPE_OPTIONS]
+const typeFormOptions = [{ value: '', label: 'Selecciona…' }, ...RELOCATION_TYPE_OPTIONS]
+const shelterFormOptions = computed(() => [{ value: '', label: 'Selecciona el refugio…' }, ...(shelters.value ?? []).map((s) => ({ value: String(s.id), label: s.name }))])
+
+const columns = [
+  { key: 'family', label: 'Familia' },
+  { key: 'route', label: 'Origen → Destino' },
+  { key: 'type', label: 'Tipo' },
+  { key: 'relocation_date', label: 'Fecha' },
+  { key: 'authorized_by', label: 'Autorizado por' },
+]
+const asReloc = (r: unknown) => r as RelocationEnriched
+
+function shelterName(id: number | null | undefined) {
+  if (id == null) return '—'
+  return shelterMap.value.get(id)?.name ?? `#${id}`
+}
+function fmtDate(s: string) {
+  return new Date(s).toLocaleDateString('es-CO', { day: '2-digit', month: 'short', year: 'numeric' })
+}
+function goTo(p: number) { page.value = Math.min(Math.max(1, p), totalPages.value) }
+
+// --- Modal nuevo traslado -----------------------------------------------------
+const modalOpen = ref(false)
+const saving = computed(() => create.isPending.value)
+const errors = ref<Record<string, string>>({})
+const familyQuery = ref('')
+const selectedFamily = ref<Family | null>(null)
+const destinationId = ref('')
+const relocType = ref('')
+const reason = ref('')
+const notes = ref('')
+
+const searchParams = computed<FamilyListParams>(() => ({
+  page: 1, limit: 8,
+  ...(familyQuery.value.trim().length >= 2 ? { q: familyQuery.value.trim() } : {}),
+}))
+const { data: familyResults } = useFamiliesList(searchParams)
+const showResults = computed(() => familyQuery.value.trim().length >= 2 && !selectedFamily.value)
+// Refugios destino: excluir el refugio actual de la familia (HU-24).
+const destinationOptions = computed(() =>
+  shelterFormOptions.value.filter((o) => !o.value || Number(o.value) !== selectedFamily.value?.shelter_id),
+)
+
+function openCreate() {
+  selectedFamily.value = null
+  familyQuery.value = ''
+  destinationId.value = ''
+  relocType.value = ''
+  reason.value = ''
+  notes.value = ''
+  errors.value = {}
+  modalOpen.value = true
+}
+function pickFamily(f: Family) {
+  selectedFamily.value = f
+  familyQuery.value = ''
+}
+async function submit() {
+  const e: Record<string, string> = {}
+  if (!selectedFamily.value) e.family = 'Selecciona una familia.'
+  if (!destinationId.value) e.destination = 'Selecciona el refugio destino.'
+  if (!relocType.value) e.type = 'Selecciona el tipo.'
+  if (reason.value.trim().length < 5) e.reason = 'El motivo es obligatorio (mín. 5 caracteres).'
+  errors.value = e
+  if (Object.keys(e).length || !selectedFamily.value) return
+
+  const payload: RelocationPayload = {
+    family_id: selectedFamily.value.id,
+    destination_shelter_id: Number(destinationId.value),
+    type: relocType.value as RelocationType,
+    reason: reason.value.trim(),
+    notes: notes.value.trim() || null,
+  }
+  try {
+    await create.mutateAsync(payload)
+    toast.success('Traslado registrado')
+    modalOpen.value = false
+  } catch (err) {
+    toast.error(apiErrorMessage(err, 'No se pudo registrar: verifica la capacidad del refugio destino (HU-24).'))
+  }
+}
+</script>
+
+<template>
+  <section class="space-y-5">
+    <PageHeader
+      title="Traslados"
+      crumb="Operaciones"
+      :subtitle="total ? `${total} ${total === 1 ? 'traslado' : 'traslados'}` : 'Reubicación de familias entre refugios (HU-24)'"
+    >
+      <template #actions>
+        <RoleGate :roles="[...EDIT_ROLES]"><AppButton @click="openCreate"><Plus /> Nuevo traslado</AppButton></RoleGate>
+      </template>
+    </PageHeader>
+
+    <div class="rounded-lg border border-neutral-200 bg-white p-4 sm:max-w-xs">
+      <SelectField v-model="typeFilter" :options="typeFilterOptions" />
+    </div>
+
+    <div v-if="isError" class="rounded-lg border border-danger-br bg-danger-bg p-6 text-center">
+      <p class="text-sm text-danger">No se pudieron cargar los traslados.</p>
+      <AppButton variant="outline" size="sm" class="mt-3" @click="() => refetch()"><RotateCcw /> Reintentar</AppButton>
+    </div>
+    <div v-else-if="isLoading" class="space-y-2 rounded-lg border border-neutral-200 bg-white p-4">
+      <SkeletonBlock v-for="n in 6" :key="n" height="44px" />
+    </div>
+
+    <template v-else>
+      <div :class="{ 'opacity-60 transition-opacity': isFetching }">
+        <DataTable :columns="columns" :rows="rows" row-key="id" min-width="820px">
+          <template #family="{ row }">
+            <span class="font-semibold text-neutral-900">{{ asReloc(row).family?.family_code ?? `#${asReloc(row).family_id}` }}</span>
+          </template>
+          <template #route="{ row }">
+            <span class="flex items-center gap-2 text-sm">
+              {{ asReloc(row).origin_shelter?.name ?? shelterName(asReloc(row).origin_shelter_id) }}
+              <MoveRight class="h-4 w-4 text-neutral-400" />
+              <span class="font-medium text-neutral-900">{{ asReloc(row).destination_shelter?.name ?? shelterName(asReloc(row).destination_shelter_id) }}</span>
+            </span>
+          </template>
+          <template #type="{ row }">{{ RELOCATION_TYPE_LABELS[asReloc(row).type] }}</template>
+          <template #relocation_date="{ row }">{{ fmtDate(asReloc(row).relocation_date) }}</template>
+          <template #authorized_by="{ row }"><span class="text-sm text-neutral-600">{{ asReloc(row).authorized_by_user?.name ?? '—' }}</span></template>
+          <template #empty>
+            <EmptyState title="Sin traslados" :message="hasFilters ? 'No hay traslados de ese tipo.' : 'Aún no se han registrado traslados.'">
+              <template #icon><MoveRight /></template>
+              <template #action>
+                <RoleGate :roles="[...EDIT_ROLES]"><AppButton size="sm" @click="openCreate"><Plus /> Nuevo traslado</AppButton></RoleGate>
+              </template>
+            </EmptyState>
+          </template>
+        </DataTable>
+      </div>
+
+      <div v-if="total > 0" class="flex flex-wrap items-center justify-between gap-3 text-sm text-neutral-600">
+        <span>{{ total }} en total</span>
+        <div class="flex items-center gap-2">
+          <AppButton variant="outline" size="sm" :disabled="page <= 1" @click="goTo(page - 1)"><ChevronLeft /></AppButton>
+          <span class="px-1">Página {{ page }} de {{ totalPages }}</span>
+          <AppButton variant="outline" size="sm" :disabled="page >= totalPages" @click="goTo(page + 1)"><ChevronRight /></AppButton>
+        </div>
+      </div>
+    </template>
+
+    <!-- Modal nuevo traslado -->
+    <BaseModal :open="modalOpen" title="Nuevo traslado" max-width="max-w-[560px]" @close="modalOpen = false">
+      <form class="space-y-4" @submit.prevent="submit">
+        <div v-if="!selectedFamily">
+          <FormField label="Familia" required :error="errors.family" input-id="rl-fam" hint="Busca por código, documento o dirección.">
+            <div class="relative">
+              <Search class="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-neutral-400" />
+              <input id="rl-fam" v-model="familyQuery" class="control pl-9" placeholder="FAM-… / documento" />
+            </div>
+          </FormField>
+          <ul v-if="showResults" class="mt-2 max-h-48 divide-y divide-neutral-100 overflow-y-auto rounded-md border border-neutral-200">
+            <li v-for="f in (familyResults?.data ?? [])" :key="f.id">
+              <button type="button" class="flex w-full items-center justify-between px-3 py-2 text-left text-sm hover:bg-primary-50" @click="pickFamily(f)">
+                <span class="font-semibold text-neutral-900">{{ f.family_code }}</span>
+                <span class="text-xs text-neutral-500">{{ f.shelter_id ? shelterName(f.shelter_id) : 'sin refugio' }}</span>
+              </button>
+            </li>
+          </ul>
+        </div>
+        <div v-else class="flex items-center justify-between rounded-md border border-neutral-200 bg-neutral-50 p-3 text-sm">
+          <span><span class="font-semibold text-neutral-900">{{ selectedFamily.family_code }}</span> · actual: {{ shelterName(selectedFamily.shelter_id) }}</span>
+          <AppButton type="button" variant="ghost" size="sm" @click="selectedFamily = null">Cambiar</AppButton>
+        </div>
+
+        <SelectField v-model="destinationId" label="Refugio destino" required :options="destinationOptions" :error="errors.destination" input-id="rl-dest" />
+        <SelectField v-model="relocType" label="Tipo de traslado" required :options="typeFormOptions" :error="errors.type" input-id="rl-type" />
+        <FormField label="Motivo" required :error="errors.reason" input-id="rl-reason">
+          <textarea id="rl-reason" v-model="reason" rows="2" class="control" placeholder="Motivo del traslado…" />
+        </FormField>
+        <FormField label="Notas" input-id="rl-notes" hint="Opcional">
+          <input id="rl-notes" v-model="notes" class="control" placeholder="Observaciones…" />
+        </FormField>
+      </form>
+      <template #footer>
+        <AppButton variant="ghost" @click="modalOpen = false">Cancelar</AppButton>
+        <AppButton :disabled="saving" @click="submit">{{ saving ? 'Registrando…' : 'Registrar traslado' }}</AppButton>
+      </template>
+    </BaseModal>
+  </section>
+</template>

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -195,6 +195,19 @@ const router = createRouter({
           component: () => import('@/pages/distributionPlans/DistributionPlanDetailPage.vue'),
           meta: { roles: ['ADMIN', 'COORDINADOR_LOGISTICA'] },
         },
+        // Operaciones — Vectores sanitarios (HU-25/26) y Traslados (HU-24).
+        {
+          path: 'health/vectors',
+          name: 'health-vectors',
+          component: () => import('@/pages/health/HealthVectorsPage.vue'),
+          meta: { roles: ['ADMIN', 'COORDINADOR_LOGISTICA'] },
+        },
+        {
+          path: 'relocations',
+          name: 'relocations',
+          component: () => import('@/pages/relocations/RelocationsPage.vue'),
+          meta: { roles: ['ADMIN', 'COORDINADOR_LOGISTICA'] },
+        },
         // Las demas rutas (mapa, etc.) se agregan aqui
         // a medida que se implementan las HU. Ver HistoriasDeUsuario.json.
       ],

--- a/client/src/types/healthVector.types.ts
+++ b/client/src/types/healthVector.types.ts
@@ -1,0 +1,74 @@
+// Tipos de vectores sanitarios (HU-25/26).
+import type { RiskLevel } from './zone.types'
+
+export type VectorType = 'AGUA_CONTAMINADA' | 'INSECTOS' | 'ROEDORES' | 'OTRO'
+export type HealthVectorStatus = 'ACTIVO' | 'EN_ATENCION' | 'RESUELTO'
+
+export const VECTOR_TYPE_OPTIONS: { value: VectorType; label: string }[] = [
+  { value: 'AGUA_CONTAMINADA', label: 'Agua contaminada' },
+  { value: 'INSECTOS', label: 'Insectos' },
+  { value: 'ROEDORES', label: 'Roedores' },
+  { value: 'OTRO', label: 'Otro' },
+]
+export const VECTOR_TYPE_LABELS = Object.fromEntries(
+  VECTOR_TYPE_OPTIONS.map((o) => [o.value, o.label]),
+) as Record<VectorType, string>
+
+export const VECTOR_STATUS_OPTIONS: { value: HealthVectorStatus; label: string }[] = [
+  { value: 'ACTIVO', label: 'Activo' },
+  { value: 'EN_ATENCION', label: 'En atención' },
+  { value: 'RESUELTO', label: 'Resuelto' },
+]
+export const VECTOR_STATUS_LABELS = Object.fromEntries(
+  VECTOR_STATUS_OPTIONS.map((o) => [o.value, o.label]),
+) as Record<HealthVectorStatus, string>
+
+// Clases del badge por estado (verde resuelto, ámbar en atención, rojo activo).
+export const VECTOR_STATUS_BADGE: Record<HealthVectorStatus, string> = {
+  ACTIVO: 'bg-danger-bg text-danger border-danger-br',
+  EN_ATENCION: 'bg-warning-bg text-warning border-warning-br',
+  RESUELTO: 'bg-success-bg text-success border-success-br',
+}
+
+export interface HealthVector {
+  id: number
+  vector_type: VectorType
+  risk_level: RiskLevel
+  status: HealthVectorStatus
+  description: string | null
+  actions_taken: string | null
+  latitude: number | null
+  longitude: number | null
+  zone_id: number | null
+  shelter_id: number | null
+  reported_date: string
+  reported_by: number
+  resolved_at: string | null
+  created_at?: string
+  updated_at?: string
+}
+
+export interface HealthVectorEnriched extends HealthVector {
+  zone?: { id: number; name: string } | null
+  shelter?: { id: number; name: string } | null
+}
+
+export interface HealthVectorListParams {
+  page: number
+  limit: number
+  zone_id?: number
+  status?: HealthVectorStatus
+  risk_level?: RiskLevel
+  vector_type?: VectorType
+}
+
+export interface HealthVectorPayload {
+  vector_type: VectorType
+  risk_level: RiskLevel
+  description?: string | null
+  latitude?: number | null
+  longitude?: number | null
+  zone_id?: number | null
+  shelter_id?: number | null
+  reported_date?: string
+}

--- a/client/src/types/relocation.types.ts
+++ b/client/src/types/relocation.types.ts
@@ -1,0 +1,61 @@
+// Tipos de traslados de familias entre refugios (HU-24).
+import type { FamilyStatus } from './family.types'
+
+export type RelocationType = 'TEMPORARY' | 'PERMANENT'
+
+export const RELOCATION_TYPE_OPTIONS: { value: RelocationType; label: string }[] = [
+  { value: 'TEMPORARY', label: 'Temporal' },
+  { value: 'PERMANENT', label: 'Permanente' },
+]
+export const RELOCATION_TYPE_LABELS = Object.fromEntries(
+  RELOCATION_TYPE_OPTIONS.map((o) => [o.value, o.label]),
+) as Record<RelocationType, string>
+
+interface ShelterRef {
+  id: number
+  name: string
+  address: string
+  max_capacity: number
+  current_occupancy: number
+}
+
+export interface RelocationEnriched {
+  id: number
+  family_id: number
+  origin_shelter_id: number | null
+  destination_shelter_id: number
+  type: RelocationType
+  relocation_date: string
+  reason: string
+  authorized_by: number
+  notes: string | null
+  created_at: string
+  family?: {
+    id: number
+    family_code: string
+    head_document: string
+    num_members: number
+    status: FamilyStatus
+    zone_id: number
+  }
+  origin_shelter?: ShelterRef | null
+  destination_shelter?: ShelterRef
+  authorized_by_user?: { id: number; name: string; role: string }
+}
+
+export interface RelocationListParams {
+  page: number
+  limit: number
+  family_id?: number
+  type?: RelocationType
+  date_from?: string
+  date_to?: string
+}
+
+export interface RelocationPayload {
+  family_id: number
+  destination_shelter_id: number
+  type: RelocationType
+  reason: string
+  notes?: string | null
+}


### PR DESCRIPTION
HealthVectorsPage (CRUD + cambio de estado + mapa, HU-25/26) y RelocationsPage (traslado con validación de capacidad destino por backend, HU-24). ✅ typecheck y build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)