### PR TITLE
feat(client): Cola offline (Dexie) + PWA (Paso 15) — HU-04 CA5 / HU-22 CA6

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -5,6 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/sigah-mark.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#1e5ba8" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@headlessui/vue": "^1.7.23",
+    "@lucide/vue": "^1.17.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/vue-query": "^5.100.14",
     "@tanstack/vue-table": "^8.21.3",
@@ -21,7 +22,7 @@
     "axios": "^1.15.0",
     "chart.js": "^4.5.1",
     "date-fns": "^4.1.0",
-    "@lucide/vue": "^1.17.0",
+    "dexie": "^4.4.3",
     "leaflet": "^1.9.4",
     "pinia": "^3.0.4",
     "tailwindcss": "^4.2.2",

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      dexie:
+        specifier: ^4.4.3
+        version: 4.4.3
       leaflet:
         specifier: ^1.9.4
         version: 1.9.4
@@ -799,6 +802,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  dexie@4.4.3:
+    resolution: {integrity: sha512-N+3IGQ3HPlyO2YAkntGAwitm42BpBGV86MttzUMiRzWLa4NGh0pltVRcUVF4ybL/OnXjCrr9k7SDPIKkFYP2Lg==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -2243,6 +2249,8 @@ snapshots:
   delayed-stream@1.0.0: {}
 
   detect-libc@2.1.2: {}
+
+  dexie@4.4.3: {}
 
   dunder-proto@1.0.1:
     dependencies:

--- a/client/public/manifest.webmanifest
+++ b/client/public/manifest.webmanifest
@@ -1,0 +1,15 @@
+{
+  "name": "SIGAH — Gestión de Ayudas Humanitarias",
+  "short_name": "SIGAH",
+  "description": "Sistema de Gestión y Distribución de Ayudas Humanitarias — Alcaldía de Montería",
+  "lang": "es-CO",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "orientation": "portrait-primary",
+  "background_color": "#f1f5f9",
+  "theme_color": "#1e5ba8",
+  "icons": [
+    { "src": "/sigah-mark.svg", "sizes": "any", "type": "image/svg+xml", "purpose": "any maskable" }
+  ]
+}

--- a/client/public/sw.js
+++ b/client/public/sw.js
@@ -1,0 +1,83 @@
+/* SIGAH Service Worker (escrito a mano, sin build step).
+   - App shell (navegaciones): NetworkFirst con fallback a index.html cacheado → permite abrir la app sin conexión.
+   - Assets estáticos (/assets, íconos): StaleWhileRevalidate.
+   - API GET (/api/v1): NetworkFirst con fallback a la última respuesta cacheada.
+   - Mutaciones (POST/PUT/DELETE): nunca se cachean; la cola Dexie del cliente las maneja offline.
+*/
+const VERSION = 'sigah-v1'
+const SHELL_CACHE = `${VERSION}-shell`
+const ASSET_CACHE = `${VERSION}-assets`
+const API_CACHE = `${VERSION}-api`
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(SHELL_CACHE).then((c) => c.add('/index.html').catch(() => undefined)),
+  )
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.filter((k) => !k.startsWith(VERSION)).map((k) => caches.delete(k))),
+    ),
+  )
+  self.clients.claim()
+})
+
+function networkFirst(request, cacheName, fallbackUrl) {
+  return fetch(request)
+    .then((res) => {
+      if (res && res.ok) {
+        const copy = res.clone()
+        caches.open(cacheName).then((c) => c.put(request, copy))
+      }
+      return res
+    })
+    .catch(async () => {
+      const cached = await caches.match(request)
+      if (cached) return cached
+      if (fallbackUrl) {
+        const shell = await caches.match(fallbackUrl)
+        if (shell) return shell
+      }
+      return new Response('', { status: 503, statusText: 'Offline' })
+    })
+}
+
+function staleWhileRevalidate(request, cacheName) {
+  return caches.open(cacheName).then(async (cache) => {
+    const cached = await cache.match(request)
+    const network = fetch(request)
+      .then((res) => {
+        if (res && res.ok) cache.put(request, res.clone())
+        return res
+      })
+      .catch(() => cached)
+    return cached || network
+  })
+}
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event
+  if (request.method !== 'GET') return // mutaciones: las gestiona la cola offline
+
+  const url = new URL(request.url)
+  const sameOrigin = url.origin === self.location.origin
+
+  // Navegaciones SPA → app shell.
+  if (request.mode === 'navigate') {
+    event.respondWith(networkFirst(request, SHELL_CACHE, '/index.html'))
+    return
+  }
+  // API GET (mismo origen, /api/v1) — excluye auth/sync (sensibles a sesión).
+  if (sameOrigin && url.pathname.startsWith('/api/v1') && !url.pathname.startsWith('/api/v1/auth') && !url.pathname.startsWith('/api/v1/sync')) {
+    event.respondWith(networkFirst(request, API_CACHE))
+    return
+  }
+  // Assets estáticos del build.
+  if (sameOrigin && (url.pathname.startsWith('/assets/') || /\.(?:js|css|svg|png|woff2?)$/.test(url.pathname))) {
+    event.respondWith(staleWhileRevalidate(request, ASSET_CACHE))
+    return
+  }
+})

--- a/client/src/api/sync.api.ts
+++ b/client/src/api/sync.api.ts
@@ -1,0 +1,23 @@
+import { api } from './axios'
+import type { ApiItem } from '@/types/api.types'
+
+export interface SyncOpInput {
+  client_op_id: string
+  method: string
+  url: string
+  payload: unknown
+}
+
+export interface SyncOpResult {
+  client_op_id: string
+  status_code: number
+  response: unknown
+  from_cache: boolean
+}
+
+export const syncApi = {
+  // POST /sync — procesa el lote de ops offline (dedup por client_op_id en el backend).
+  processBatch(ops: SyncOpInput[]) {
+    return api.post<ApiItem<SyncOpResult[]>>('/sync', { ops }).then((r) => r.data.data)
+  },
+}

--- a/client/src/components/layout/ConnectionBadge.vue
+++ b/client/src/components/layout/ConnectionBadge.vue
@@ -1,10 +1,16 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { storeToRefs } from 'pinia'
+import { toast } from 'vue-sonner'
+import { RefreshCw } from '@lucide/vue'
 import { useSyncStore } from '@/stores/sync'
+import { allOps, type PendingOp } from '@/lib/offlineQueue'
+import { flushQueue } from '@/lib/syncManager'
+import BaseModal from '@/components/ui/BaseModal.vue'
+import AppButton from '@/components/ui/AppButton.vue'
 
 const sync = useSyncStore()
-const { status, pendingCount } = storeToRefs(sync)
+const { status, pendingCount, lastSyncAt } = storeToRefs(sync)
 
 const cfg = computed(
   () =>
@@ -14,22 +20,69 @@ const cfg = computed(
       offline: { label: 'Sin conexión', cls: 'text-danger bg-danger-bg border-danger-br', dot: 'bg-danger' },
     })[status.value],
 )
+
+const open = ref(false)
+const ops = ref<PendingOp[]>([])
+const syncing = computed(() => status.value === 'syncing')
+
+async function openPanel() {
+  ops.value = await allOps()
+  open.value = true
+}
+async function syncNow() {
+  if (!navigator.onLine) {
+    toast.error('Sin conexión: no se puede sincronizar todavía.')
+    return
+  }
+  const res = await flushQueue()
+  ops.value = await allOps()
+  if (res) {
+    toast.success(`Sincronización: ${res.sent} enviada(s)${res.failed ? `, ${res.failed} con error` : ''}`)
+  }
+}
+function fmt(s: string | null) {
+  return s ? new Date(s).toLocaleString('es-CO', { dateStyle: 'short', timeStyle: 'short' }) : '—'
+}
 </script>
 
 <template>
-  <span
+  <button
+    type="button"
     :class="['inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium', cfg.cls]"
+    @click="openPanel"
   >
     <span class="relative flex h-2 w-2">
-      <span
-        v-if="status === 'online'"
-        :class="['absolute inline-flex h-full w-full animate-ping rounded-full opacity-60', cfg.dot]"
-      />
+      <span v-if="status === 'online'" :class="['absolute inline-flex h-full w-full animate-ping rounded-full opacity-60', cfg.dot]" />
       <span :class="['relative inline-flex h-2 w-2 rounded-full', cfg.dot]" />
     </span>
     {{ cfg.label }}
-    <span v-if="pendingCount > 0" class="rounded-full bg-neutral-900/10 px-1.5 text-xs font-bold">
-      {{ pendingCount }}
-    </span>
-  </span>
+    <span v-if="pendingCount > 0" class="rounded-full bg-neutral-900/10 px-1.5 text-xs font-bold">{{ pendingCount }}</span>
+  </button>
+
+  <BaseModal :open="open" title="Sincronización offline" max-width="max-w-[520px]" @close="open = false">
+    <div class="space-y-4">
+      <div class="flex items-center justify-between text-sm">
+        <span class="text-neutral-600">Estado: <strong :class="cfg.cls.split(' ')[0]">{{ cfg.label }}</strong></span>
+        <span class="text-neutral-500">Última sinc.: {{ fmt(lastSyncAt) }}</span>
+      </div>
+
+      <div v-if="ops.length" class="space-y-2">
+        <p class="text-sm text-neutral-600">{{ ops.length }} operación(es) pendiente(s) de sincronizar:</p>
+        <ul class="max-h-64 divide-y divide-neutral-100 overflow-y-auto rounded-md border border-neutral-200">
+          <li v-for="op in ops" :key="op.client_op_id" class="flex items-center justify-between gap-2 px-3 py-2 text-sm">
+            <span class="min-w-0">
+              <span class="font-medium text-neutral-900">{{ op.label }}</span>
+              <span class="block text-xs text-neutral-400">{{ fmt(op.created_at) }}<span v-if="op.last_error"> · {{ op.last_error }}</span></span>
+            </span>
+            <span v-if="op.attempts > 0" class="rounded-full bg-warning-bg px-2 py-0.5 text-xs text-warning">{{ op.attempts }} intento(s)</span>
+          </li>
+        </ul>
+      </div>
+      <p v-else class="rounded-md bg-success-bg p-3 text-sm text-success">Todo sincronizado. No hay operaciones pendientes.</p>
+    </div>
+    <template #footer>
+      <AppButton variant="ghost" @click="open = false">Cerrar</AppButton>
+      <AppButton :disabled="syncing || !ops.length || !cfg" @click="syncNow"><RefreshCw /> Sincronizar ahora</AppButton>
+    </template>
+  </BaseModal>
 </template>

--- a/client/src/composables/useConnection.ts
+++ b/client/src/composables/useConnection.ts
@@ -1,13 +1,15 @@
 import { onMounted, onUnmounted } from 'vue'
 import { useSyncStore } from '@/stores/sync'
+import { flushQueue, refreshPending } from '@/lib/syncManager'
 
-// Sincroniza el estado online/offline del navegador con el sync store.
-// El disparo del flush de la cola offline se conectara aqui (syncManager).
+// Sincroniza el estado online/offline del navegador con el sync store y dispara
+// el flush de la cola offline al recuperar conexión (HU-04 CA5, HU-22 CA6).
 export function useConnection() {
   const sync = useSyncStore()
 
   function goOnline() {
     sync.setStatus('online')
+    void flushQueue()
   }
   function goOffline() {
     sync.setStatus('offline')
@@ -16,6 +18,10 @@ export function useConnection() {
   onMounted(() => {
     window.addEventListener('online', goOnline)
     window.addEventListener('offline', goOffline)
+    // Inicializa el contador de pendientes y vacía la cola si arrancamos online.
+    void refreshPending().then(() => {
+      if (navigator.onLine) void flushQueue()
+    })
   })
 
   onUnmounted(() => {

--- a/client/src/composables/useOfflineSync.ts
+++ b/client/src/composables/useOfflineSync.ts
@@ -1,0 +1,46 @@
+import axios from 'axios'
+import { enqueueOp, type OfflineEntity } from '@/lib/offlineQueue'
+import { refreshPending, flushQueue } from '@/lib/syncManager'
+
+interface SubmitArgs<T> {
+  entity: OfflineEntity
+  url: string // ruta completa incl. /api/v1 (la usa POST /sync para enrutar)
+  payload: unknown
+  clientOpId: string
+  label: string
+  run: () => Promise<T> // intento online (la llamada real a la API)
+}
+
+export type SubmitResult<T> = { status: 'sent'; data: T } | { status: 'queued' }
+
+// Un error de red (request enviado, sin respuesta) ⇒ sin conexión ⇒ encolar.
+// Un error con respuesta (4xx/5xx) es un error real de negocio ⇒ propagar.
+function isNetworkError(e: unknown): boolean {
+  return axios.isAxiosError(e) && !e.response
+}
+
+export function useOfflineSync() {
+  async function submit<T>(args: SubmitArgs<T>): Promise<SubmitResult<T>> {
+    if (navigator.onLine) {
+      try {
+        const data = await args.run()
+        return { status: 'sent', data }
+      } catch (e) {
+        if (!isNetworkError(e)) throw e
+        // Error de red: cae al encolado de abajo.
+      }
+    }
+    await enqueueOp({
+      entity: args.entity,
+      method: 'POST',
+      url: args.url,
+      payload: args.payload,
+      label: args.label,
+      client_op_id: args.clientOpId,
+    })
+    await refreshPending()
+    return { status: 'queued' }
+  }
+
+  return { submit, flushQueue }
+}

--- a/client/src/lib/offlineQueue.ts
+++ b/client/src/lib/offlineQueue.ts
@@ -1,0 +1,56 @@
+// Cola de operaciones offline en IndexedDB (Dexie) — HU-04 CA5, HU-22 CA6.
+// Las mutaciones que no se pueden enviar (sin conexión) se persisten aquí y se
+// reenvían al recuperar conexión vía POST /sync con dedup por client_op_id.
+import Dexie, { type Table } from 'dexie'
+
+export type OfflineEntity = 'family' | 'person' | 'delivery'
+
+export interface PendingOp {
+  id?: number
+  client_op_id: string
+  entity: OfflineEntity
+  method: 'POST' | 'PUT' | 'DELETE'
+  url: string // ruta completa incl. /api/v1 (el backend /sync enruta por url)
+  payload: unknown
+  label: string // descripción legible para el panel de sincronización
+  created_at: string
+  attempts: number
+  last_error?: string
+}
+
+// El frontend rechaza acumular más de 200 ops pendientes por usuario (FRONTEND-PLAN §10).
+export const MAX_PENDING_OPS = 200
+
+class SigahOfflineDB extends Dexie {
+  pendingOps!: Table<PendingOp, number>
+  constructor() {
+    super('sigah-offline')
+    this.version(1).stores({ pendingOps: '++id, client_op_id, entity, created_at' })
+  }
+}
+
+export const offlineDB = new SigahOfflineDB()
+
+export async function countOps(): Promise<number> {
+  return offlineDB.pendingOps.count()
+}
+
+export async function enqueueOp(op: Omit<PendingOp, 'id' | 'created_at' | 'attempts'>): Promise<number> {
+  const count = await countOps()
+  if (count >= MAX_PENDING_OPS) {
+    throw new Error(`Límite de ${MAX_PENDING_OPS} operaciones offline alcanzado. Recupera la conexión para sincronizar.`)
+  }
+  return offlineDB.pendingOps.add({ ...op, created_at: new Date().toISOString(), attempts: 0 })
+}
+
+export async function allOps(): Promise<PendingOp[]> {
+  return offlineDB.pendingOps.orderBy('created_at').toArray()
+}
+
+export async function removeOp(id: number): Promise<void> {
+  await offlineDB.pendingOps.delete(id)
+}
+
+export async function updateOp(id: number, changes: Partial<PendingOp>): Promise<void> {
+  await offlineDB.pendingOps.update(id, changes)
+}

--- a/client/src/lib/syncManager.ts
+++ b/client/src/lib/syncManager.ts
@@ -1,0 +1,69 @@
+// Flush de la cola offline: reenvía las ops pendientes a POST /sync y reconcilia
+// la cola según el status_code de cada resultado. HU-04 CA5, HU-22 CA6.
+import { allOps, countOps, removeOp, updateOp } from './offlineQueue'
+import { syncApi } from '@/api/sync.api'
+import { useSyncStore } from '@/stores/sync'
+import { queryClient } from './queryClient'
+
+let flushing = false
+
+// Sincroniza el contador de pendientes con la cola (para el ConnectionBadge).
+export async function refreshPending(): Promise<number> {
+  const n = await countOps()
+  useSyncStore().setPendingCount(n)
+  return n
+}
+
+export async function flushQueue(): Promise<{ sent: number; failed: number } | null> {
+  if (flushing || !navigator.onLine) return null
+  const sync = useSyncStore()
+  const ops = await allOps()
+  if (!ops.length) {
+    sync.setPendingCount(0)
+    return null
+  }
+
+  flushing = true
+  sync.setStatus('syncing')
+  try {
+    const results = await syncApi.processBatch(
+      ops.map((o) => ({ client_op_id: o.client_op_id, method: o.method, url: o.url, payload: o.payload })),
+    )
+    const byKey = new Map(ops.map((o) => [o.client_op_id, o]))
+    let sent = 0
+    let failed = 0
+
+    for (const r of results) {
+      const op = byKey.get(r.client_op_id)
+      if (!op?.id) continue
+      if (r.status_code < 400 || r.from_cache) {
+        await removeOp(op.id)
+        sent++
+      } else if (r.status_code < 500) {
+        // Falla permanente (validación/conflicto): no reintentar — quitar y reportar.
+        await removeOp(op.id)
+        failed++
+      } else {
+        // 5xx: reintentable; conserva e incrementa intentos.
+        await updateOp(op.id, { attempts: op.attempts + 1, last_error: `Error ${r.status_code}` })
+      }
+    }
+
+    // Refresca los datos que pudieron cambiar al aplicar las ops.
+    queryClient.invalidateQueries({ queryKey: ['families'] })
+    queryClient.invalidateQueries({ queryKey: ['deliveries'] })
+    queryClient.invalidateQueries({ queryKey: ['prioritization'] })
+    queryClient.invalidateQueries({ queryKey: ['warehouses'] })
+
+    await refreshPending()
+    sync.markSynced(new Date().toISOString())
+    sync.setStatus(navigator.onLine ? 'online' : 'offline')
+    return { sent, failed }
+  } catch {
+    // El POST /sync falló (probablemente se perdió la conexión): conserva la cola.
+    sync.setStatus(navigator.onLine ? 'online' : 'offline')
+    return null
+  } finally {
+    flushing = false
+  }
+}

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -13,3 +13,11 @@ app.use(router)
 app.use(VueQueryPlugin, { queryClient })
 
 app.mount('#app')
+
+// PWA: registra el service worker (app shell + caché offline). Solo en producción;
+// en dev interferiría con el HMR de Vite. La cola de escrituras la maneja Dexie.
+if ('serviceWorker' in navigator && import.meta.env.PROD) {
+  window.addEventListener('load', () => {
+    void navigator.serviceWorker.register('/sw.js').catch(() => undefined)
+  })
+}

--- a/client/src/pages/deliveries/DeliveryFormPage.vue
+++ b/client/src/pages/deliveries/DeliveryFormPage.vue
@@ -15,6 +15,7 @@ import type { DeliveryDetailInput, DeliveryPayload, ExceptionPayload } from '@/t
 import type { ResourceTypeListParams } from '@/types/inventory.types'
 import { FOOD_KG_PER_PERSON_DAY, MIN_COVERAGE_DAYS } from '@/utils/constants'
 import { apiErrorMessage } from '@/utils/apiError'
+import { useOfflineSync } from '@/composables/useOfflineSync'
 import PageHeader from '@/components/ui/PageHeader.vue'
 import AppButton from '@/components/ui/AppButton.vue'
 import FormField from '@/components/form/FormField.vue'
@@ -95,6 +96,7 @@ const isEligible = computed(() => eligibility.value?.is_eligible ?? true)
 const blockedByCoverage = computed(() => !isEligible.value && !exceptionMode.value)
 
 const { create, createException } = useDeliveryMutations()
+const offline = useOfflineSync()
 const saving = computed(() => create.isPending.value || createException.isPending.value)
 const clientOpId = ref(crypto.randomUUID())
 
@@ -148,8 +150,20 @@ async function submit() {
       toast.success(`Entrega ${created.delivery_code} creada con excepción`)
     } else {
       const payload: DeliveryPayload = { ...base, client_op_id: clientOpId.value }
-      const created = await create.mutateAsync({ payload, clientOpId: clientOpId.value })
-      toast.success(`Entrega ${created.delivery_code} registrada`)
+      // Entrega offline (HU-22 CA6): si no hay conexión, se guarda localmente.
+      const res = await offline.submit({
+        entity: 'delivery',
+        url: '/api/v1/deliveries',
+        payload,
+        clientOpId: clientOpId.value,
+        label: `Entrega · familia ${selectedFamily.value.family_code}`,
+        run: () => create.mutateAsync({ payload, clientOpId: clientOpId.value }),
+      })
+      if (res.status === 'sent') {
+        toast.success(`Entrega ${res.data.delivery_code} registrada`)
+      } else {
+        toast.success('Sin conexión: entrega guardada localmente. Se sincronizará al reconectar.')
+      }
     }
     router.push('/deliveries')
   } catch (e) {

--- a/client/src/pages/families/FamilyFormPage.vue
+++ b/client/src/pages/families/FamilyFormPage.vue
@@ -11,6 +11,7 @@ import type { FamilyCreatePayload, FamilyStatus, FamilyUpdatePayload } from '@/t
 import { familyCreateSchema, familyEditSchema } from '@/schemas/family.schema'
 import { validate } from '@/utils/validation'
 import { apiErrorMessage } from '@/utils/apiError'
+import { useOfflineSync } from '@/composables/useOfflineSync'
 import PageHeader from '@/components/ui/PageHeader.vue'
 import AppButton from '@/components/ui/AppButton.vue'
 import SkeletonBlock from '@/components/ui/SkeletonBlock.vue'
@@ -29,6 +30,7 @@ const { data: family, isLoading: loadingFamily, isError: familyError } = useFami
 const { data: zones } = useZones()
 const { data: shelters } = useShelters()
 const { create, update } = useFamilyMutations()
+const offline = useOfflineSync()
 const saving = computed(() => create.isPending.value || update.isPending.value)
 
 // Clave de idempotencia estable por instancia del formulario: un reintento de un
@@ -161,9 +163,23 @@ async function submit() {
     privacy_consent_accepted: true,
   }
   try {
-    const created = await create.mutateAsync({ payload, clientOpId: clientOpId.value })
-    toast.success(`Familia ${created.family_code} registrada`)
-    router.push(`/families/${created.id}`)
+    // Censo offline (HU-04 CA5): si no hay conexión, se guarda localmente y se
+    // sincroniza al reconectar (dedup por client_op_id).
+    const res = await offline.submit({
+      entity: 'family',
+      url: '/api/v1/families',
+      payload,
+      clientOpId: clientOpId.value,
+      label: `Familia (doc ${payload.head_document})`,
+      run: () => create.mutateAsync({ payload, clientOpId: clientOpId.value }),
+    })
+    if (res.status === 'sent') {
+      toast.success(`Familia ${res.data.family_code} registrada`)
+      router.push(`/families/${res.data.id}`)
+    } else {
+      toast.success('Sin conexión: familia guardada localmente. Se sincronizará al reconectar.')
+      router.push('/families')
+    }
   } catch (e) {
     toast.error(apiErrorMessage(e, 'No se pudo registrar la familia. ¿El documento ya existe?'))
   }


### PR DESCRIPTION
Cola offline en IndexedDB (Dexie) con flush a `POST /sync` (dedup por client_op_id) al reconectar; `useOfflineSync` enviar-o-encolar integrado en alta de familia y de entrega; ConnectionBadge con panel de pendientes + sincronizar ahora; PWA (manifest + service worker hecho a mano: app shell offline + caché de GETs). ✅ typecheck y build; sw.js+manifest en dist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)